### PR TITLE
Replaced AWSLogsClient by AWSLogsClientBuilder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,6 @@ target/
 .classpath
 .settings/
 
+.idea/
+*.iml
 TODO

--- a/appenders/pom.xml
+++ b/appenders/pom.xml
@@ -40,7 +40,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <aws-sdk.version>1.11.0</aws-sdk.version>
+        <aws-sdk.version>1.11.254</aws-sdk.version>
         <junit.version>4.10</junit.version>
         <kdgcommons.version>1.0.15</kdgcommons.version>
         <log4j.version>1.2.16</log4j.version>

--- a/appenders/src/main/java/com/kdgregory/log4j/aws/internal/cloudwatch/CloudWatchLogWriter.java
+++ b/appenders/src/main/java/com/kdgregory/log4j/aws/internal/cloudwatch/CloudWatchLogWriter.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import com.amazonaws.services.logs.AWSLogsClientBuilder;
 import org.apache.log4j.helpers.LogLog;
 
 import com.amazonaws.services.logs.AWSLogs;
@@ -39,7 +40,7 @@ extends AbstractLogWriter
     @Override
     protected void createAWSClient()
     {
-        client = new AWSLogsClient();
+        client = AWSLogsClientBuilder.defaultClient();
     }
 
 


### PR DESCRIPTION
Hi,

I upgraded the AWS SDK version to the latest bugfix version and added the AWSLogsClientBuilder because 
- AWSLogsClient is deprecated
- AWSLogsClientBuilder will use DefaultAWSCredentialsProviderChain and DefaultAwsRegionProviderChain : this will allow users of the appender set another region and other users by providing them in configuration files or as system environment variables 