### PR TITLE
unit test refactoring

### DIFF
--- a/appenders/src/test/java/com/kdgregory/log4j/aws/TestCloudWatchAppender.java
+++ b/appenders/src/test/java/com/kdgregory/log4j/aws/TestCloudWatchAppender.java
@@ -15,43 +15,40 @@
 package com.kdgregory.log4j.aws;
 
 import java.net.URL;
-import java.util.ArrayList;
-import java.util.List;
 
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-
 import static org.junit.Assert.*;
-import static net.sf.kdgcommons.test.StringAsserts.*;
 
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
 import org.apache.log4j.PropertyConfigurator;
 import org.apache.log4j.helpers.LogLog;
 
-import net.sf.kdgcommons.lang.ClassUtil;
 import net.sf.kdgcommons.lang.StringUtil;
+import static net.sf.kdgcommons.test.StringAsserts.*;
 
 import com.amazonaws.services.logs.AWSLogs;
-import com.amazonaws.services.logs.model.DescribeLogGroupsRequest;
-import com.amazonaws.services.logs.model.DescribeLogGroupsResult;
-import com.amazonaws.services.logs.model.InputLogEvent;
-import com.amazonaws.services.logs.model.PutLogEventsRequest;
-import com.amazonaws.services.logs.model.PutLogEventsResult;
 
 import com.kdgregory.log4j.aws.internal.cloudwatch.CloudWatchAppenderStatistics;
 import com.kdgregory.log4j.aws.internal.cloudwatch.CloudWatchWriterConfig;
-import com.kdgregory.log4j.aws.internal.cloudwatch.CloudWatchWriterFactory;
-import com.kdgregory.log4j.aws.internal.shared.AbstractLogWriter;
 import com.kdgregory.log4j.aws.internal.shared.DefaultThreadFactory;
 import com.kdgregory.log4j.aws.internal.shared.LogMessage;
-import com.kdgregory.log4j.aws.internal.shared.MessageQueue;
-import com.kdgregory.log4j.aws.internal.shared.MessageQueue.DiscardAction;
-import com.kdgregory.log4j.testhelpers.*;
-import com.kdgregory.log4j.testhelpers.aws.cloudwatch.*;
+import com.kdgregory.log4j.testhelpers.HeaderFooterLayout;
+import com.kdgregory.log4j.testhelpers.InlineThreadFactory;
+import com.kdgregory.log4j.testhelpers.TestingException;
+import com.kdgregory.log4j.testhelpers.ThrowingWriterFactory;
+import com.kdgregory.log4j.testhelpers.aws.cloudwatch.MockCloudWatchClient;
+import com.kdgregory.log4j.testhelpers.aws.cloudwatch.MockCloudWatchWriter;
+import com.kdgregory.log4j.testhelpers.aws.cloudwatch.MockCloudWatchWriterFactory;
+import com.kdgregory.log4j.testhelpers.aws.cloudwatch.TestableCloudWatchAppender;
 
 
+/**
+ *  These tests exercise the high-level logic of the appender: configuration
+ *  and interaction with the writer. To do so, it mocks the LogWriter.
+ */
 public class TestCloudWatchAppender
 {
     private Logger logger;
@@ -72,26 +69,6 @@ public class TestCloudWatchAppender
 
         appender.setThreadFactory(new InlineThreadFactory());
         appender.setWriterFactory(new MockCloudWatchWriterFactory(appender));
-    }
-
-
-    /**
-     *  A spin loop that waits for an writer running in another thread to
-     *  finish initialization, either successfully or with error.
-     */
-    private void waitForInitialization() throws Exception
-    {
-        for (int ii = 0 ; ii < 50 ; ii++)
-        {
-            AbstractLogWriter writer = (AbstractLogWriter)appender.getWriter();
-            if ((writer != null) && writer.isInitializationComplete())
-                return;
-            else if (appender.getAppenderStatistics().getLastErrorMessage() != null)
-                return;
-            else
-                Thread.sleep(100);
-        }
-        fail("timed out waiting for initialization");
     }
 
 
@@ -420,290 +397,6 @@ public class TestCloudWatchAppender
 
 
     @Test
-    public void testWriterWithExistingGroupAndStream() throws Exception
-    {
-        initialize("TestCloudWatchAppender/testWriterWithExistingGroupAndStream.properties");
-
-        MockCloudWatchClient mockClient = new MockCloudWatchClient();
-
-        // note that we will be running the writer on a separate thread
-        appender.setThreadFactory(new DefaultThreadFactory());
-        appender.setWriterFactory(mockClient.newWriterFactory());
-
-        logger.debug("message one");
-        mockClient.allowWriterThread();
-
-        // will call describeLogGroups when checking group existence
-        // will call describeLogStreams when checking stream existence, as well as for each putLogEvents
-
-        assertEquals("describeLogGroups: invocation count",   2,                mockClient.describeLogGroupsInvocationCount);
-        assertEquals("describeLogStreams: invocation count",  4,                mockClient.describeLogStreamsInvocationCount);
-        assertEquals("createLogGroup: invocation count",      0,                mockClient.createLogGroupInvocationCount);
-        assertEquals("createLogStream: invocation count",     0,                mockClient.createLogStreamInvocationCount);
-        assertEquals("putLogEvents: invocation count",        1,                mockClient.putLogEventsInvocationCount);
-        assertEquals("putLogEvents: last call #/messages",    1,                mockClient.mostRecentEvents.size());
-        assertEquals("putLogEvents: last message",            "message one\n",  mockClient.mostRecentEvents.get(0).getMessage());
-
-        logger.debug("message two");
-        mockClient.allowWriterThread();
-
-        assertEquals("describeLogGroups: invocation count",   2,                mockClient.describeLogGroupsInvocationCount);
-        assertEquals("describeLogStreams: invocation count",  6,                mockClient.describeLogStreamsInvocationCount);
-        assertEquals("createLogGroup: invocation count",      0,                mockClient.createLogGroupInvocationCount);
-        assertEquals("createLogStream: invocation count",     0,                mockClient.createLogStreamInvocationCount);
-        assertEquals("putLogEvents: invocation count",        2,                mockClient.putLogEventsInvocationCount);
-        assertEquals("putLogEvents: last call #/messages",    1,                mockClient.mostRecentEvents.size());
-        assertEquals("putLogEvents: last message",            "message two\n",  mockClient.mostRecentEvents.get(0).getMessage());
-
-        assertEquals("messages sent, from statistics",          2,              appender.getAppenderStatistics().getMessagesSent());
-        assertEquals("actual log group name, from statistics",  "argle",        appender.getAppenderStatistics().getActualLogGroupName());
-        assertEquals("actual log stream name, from statistics", "bargle",       appender.getAppenderStatistics().getActualLogStreamName());
-    }
-
-
-    @Test
-    public void testWriterWithExistingGroupNewStream() throws Exception
-    {
-        initialize("TestCloudWatchAppender/testWriterWithExistingGroupNewStream.properties");
-
-        MockCloudWatchClient mockClient = new MockCloudWatchClient();
-
-        // note that we will be running the writer on a separate thread
-        appender.setThreadFactory(new DefaultThreadFactory());
-        appender.setWriterFactory(mockClient.newWriterFactory());
-
-        logger.debug("message one");
-        mockClient.allowWriterThread();
-
-        // will call describeLogGroups when checking group existence
-        // will call describeLogStreams before and after creating stream, as well as for each putLogEvents
-
-        assertEquals("describeLogGroups: invocation count",   2,                mockClient.describeLogGroupsInvocationCount);
-        assertEquals("describeLogStreams: invocation count",  6,                mockClient.describeLogStreamsInvocationCount);
-        assertEquals("createLogGroup: invocation count",      0,                mockClient.createLogGroupInvocationCount);
-        assertEquals("createLogStream: invocation count",     1,                mockClient.createLogStreamInvocationCount);
-        assertEquals("createLogStream: group name",           "argle",          mockClient.createLogStreamGroupName);
-        assertEquals("createLogStream: stream name",          "zippy-0",        mockClient.createLogStreamStreamName);
-        assertEquals("putLogEvents: invocation count",        1,                mockClient.putLogEventsInvocationCount);
-        assertEquals("putLogEvents: last call #/messages",    1,                mockClient.mostRecentEvents.size());
-        assertEquals("putLogEvents: last message",            "message one\n",  mockClient.mostRecentEvents.get(0).getMessage());
-
-        logger.debug("message two");
-        mockClient.allowWriterThread();
-
-        assertEquals("describeLogGroups: invocation count",   2,                mockClient.describeLogGroupsInvocationCount);
-        assertEquals("describeLogStreams: invocation count",  8,                mockClient.describeLogStreamsInvocationCount);
-        assertEquals("createLogGroup: invocation count",      0,                mockClient.createLogGroupInvocationCount);
-        assertEquals("createLogStream: invocation count",     1,                mockClient.createLogStreamInvocationCount);
-        assertEquals("createLogStream: group name",           "argle",          mockClient.createLogStreamGroupName);
-        assertEquals("createLogStream: stream name",          "zippy-0",        mockClient.createLogStreamStreamName);
-        assertEquals("putLogEvents: invocation count",        2,                mockClient.putLogEventsInvocationCount);
-        assertEquals("putLogEvents: last call #/messages",    1,                mockClient.mostRecentEvents.size());
-        assertEquals("putLogEvents: last message",            "message two\n",  mockClient.mostRecentEvents.get(0).getMessage());
-
-        assertEquals("messages sent, from statistics",          2,              appender.getAppenderStatistics().getMessagesSent());
-        assertEquals("actual log group name, from statistics",  "argle",        appender.getAppenderStatistics().getActualLogGroupName());
-        assertEquals("actual log stream name, from statistics", "zippy-0",      appender.getAppenderStatistics().getActualLogStreamName());
-    }
-
-
-    @Test
-    public void testWriterWithNewGroupAndStream() throws Exception
-    {
-        initialize("TestCloudWatchAppender/testWriterWithNewGroupAndStream.properties");
-
-        MockCloudWatchClient mockClient = new MockCloudWatchClient();
-
-        // note that we will be running the writer on a separate thread
-        appender.setThreadFactory(new DefaultThreadFactory());
-        appender.setWriterFactory(mockClient.newWriterFactory());
-
-        logger.debug("message one");
-        mockClient.allowWriterThread();
-
-        // will call describeLogGroups both before and after creating group
-        // will call describeLogStreams before and after creating stream, as well as for each putLogEvents
-
-        assertEquals("describeLogGroups: invocation count",   4,                mockClient.describeLogGroupsInvocationCount);
-        assertEquals("describeLogStreams: invocation count",  6,                mockClient.describeLogStreamsInvocationCount);
-        assertEquals("createLogGroup: invocation count",      1,                mockClient.createLogGroupInvocationCount);
-        assertEquals("createLogGroup: group name",            "griffy",         mockClient.createLogGroupGroupName);
-        assertEquals("createLogStream: invocation count",     1,                mockClient.createLogStreamInvocationCount);
-        assertEquals("createLogStream: group name",           "griffy",         mockClient.createLogStreamGroupName);
-        assertEquals("createLogStream: stream name",          "zippy",          mockClient.createLogStreamStreamName);
-        assertEquals("putLogEvents: invocation count",        1,                mockClient.putLogEventsInvocationCount);
-        assertEquals("putLogEvents: last call #/messages",    1,                mockClient.mostRecentEvents.size());
-        assertEquals("putLogEvents: last message",            "message one\n",  mockClient.mostRecentEvents.get(0).getMessage());
-
-        logger.debug("message two");
-        mockClient.allowWriterThread();
-
-        assertEquals("describeLogGroups: invocation count",   4,                mockClient.describeLogGroupsInvocationCount);
-        assertEquals("describeLogStreams: invocation count",  8,                mockClient.describeLogStreamsInvocationCount);
-        assertEquals("createLogGroup: invocation count",      1,                mockClient.createLogGroupInvocationCount);
-        assertEquals("createLogGroup: group name",            "griffy",         mockClient.createLogGroupGroupName);
-        assertEquals("createLogStream: invocation count",     1,                mockClient.createLogStreamInvocationCount);
-        assertEquals("createLogStream: group name",           "griffy",         mockClient.createLogStreamGroupName);
-        assertEquals("createLogStream: stream name",          "zippy",          mockClient.createLogStreamStreamName);
-        assertEquals("putLogEvents: invocation count",        2,                mockClient.putLogEventsInvocationCount);
-        assertEquals("putLogEvents: last call #/messages",    1,                mockClient.mostRecentEvents.size());
-        assertEquals("putLogEvents: last message",            "message two\n",  mockClient.mostRecentEvents.get(0).getMessage());
-
-        assertEquals("messages sent, from statistics",          2,              appender.getAppenderStatistics().getMessagesSent());
-        assertEquals("actual log group name, from statistics",  "griffy",       appender.getAppenderStatistics().getActualLogGroupName());
-        assertEquals("actual log stream name, from statistics", "zippy",        appender.getAppenderStatistics().getActualLogStreamName());
-    }
-
-
-    @Test
-    public void testInvalidGroupName() throws Exception
-    {
-        initialize("TestCloudWatchAppender/testInvalidGroupName.properties");
-
-        MockCloudWatchClient mockClient = new MockCloudWatchClient();
-
-        // note that we will be running the writer on a separate thread
-        appender.setThreadFactory(new DefaultThreadFactory());
-        appender.setWriterFactory(mockClient.newWriterFactory());
-
-        logger.debug("message one");
-
-        waitForInitialization();
-        String initializationMessage = appender.getAppenderStatistics().getLastErrorMessage();
-
-        assertTrue("initialization message indicates invalid group name (was: " + initializationMessage + ")",
-                   initializationMessage.contains("invalid log group name"));
-        assertTrue("initialization message contains invalid name (was: " + initializationMessage + ")",
-                   initializationMessage.contains("helpme!"));
-
-        assertEquals("describeLogGroups: should not be invoked",    0,  mockClient.describeLogGroupsInvocationCount);
-        assertEquals("describeLogStreams: should not be invoked",   0,  mockClient.describeLogStreamsInvocationCount);
-    }
-
-
-    @Test
-    public void testInvalidStreamName() throws Exception
-    {
-        initialize("TestCloudWatchAppender/testInvalidStreamName.properties");
-
-        MockCloudWatchClient mockClient = new MockCloudWatchClient();
-
-        // note that we will be running the writer on a separate thread
-        appender.setThreadFactory(new DefaultThreadFactory());
-        appender.setWriterFactory(mockClient.newWriterFactory());
-
-        logger.debug("message one");
-
-        waitForInitialization();
-        String initializationMessage = appender.getAppenderStatistics().getLastErrorMessage();
-
-        assertTrue("initialization message indicates invalid stream name (was: " + initializationMessage + ")",
-                   initializationMessage.contains("invalid log stream name"));
-        assertTrue("initialization message contains invalid name (was: " + initializationMessage + ")",
-                   initializationMessage.contains("I:Am:Not"));
-
-        assertEquals("describeLogGroups: should not be invoked",    0,  mockClient.describeLogGroupsInvocationCount);
-        assertEquals("describeLogStreams: should not be invoked",   0,  mockClient.describeLogStreamsInvocationCount);
-    }
-
-
-    @Test
-    public void testInitializationErrorHandling() throws Exception
-    {
-        initialize("TestCloudWatchAppender/testInitializationErrorHandling.properties");
-
-        MockCloudWatchClient mockClient = new MockCloudWatchClient()
-        {
-            @Override
-            protected DescribeLogGroupsResult describeLogGroups(DescribeLogGroupsRequest request)
-            {
-                throw new TestingException("not now, not ever");
-            }
-        };
-
-        // note that we will be running the writer on a separate thread
-        appender.setThreadFactory(new DefaultThreadFactory());
-        appender.setWriterFactory(mockClient.newWriterFactory());
-
-        // first message triggers writer creation
-
-        logger.debug("message one");
-
-        waitForInitialization();
-        String initializationMessage = appender.getAppenderStatistics().getLastErrorMessage();
-        Throwable initializationError = appender.getAppenderStatistics().getLastError();
-
-        AbstractLogWriter writer = (AbstractLogWriter)appender.getWriter();
-        MessageQueue messageQueue = ClassUtil.getFieldValue(writer, "messageQueue", MessageQueue.class);
-
-        assertEquals("describeLogGroups: invocation count",     1,                          mockClient.describeLogGroupsInvocationCount);
-        assertEquals("describeLogStreams: invocation count",    0,                          mockClient.describeLogStreamsInvocationCount);
-
-        assertNotNull("writer still exists",                                                writer);
-        assertTrue("initialization message was non-blank",                                  ! initializationMessage.equals(""));
-        assertEquals("initialization exception retained",       TestingException.class,     initializationError.getClass());
-        assertEquals("initialization error message",            "not now, not ever",        initializationError.getMessage());
-
-
-        assertEquals("message queue set to discard all",        0,                          messageQueue.getDiscardThreshold());
-        assertEquals("message queue set to discard all",        DiscardAction.oldest,       messageQueue.getDiscardAction());
-        assertEquals("messages in queue (initial)",             1,                          messageQueue.toList().size());
-
-        // trying to log another message should clear the queue
-
-        logger.info("message two");
-        assertEquals("messages in queue (second try)",          0,                          messageQueue.toList().size());
-    }
-
-
-    @Test
-    public void testBatchExceptionHandling() throws Exception
-    {
-        initialize("TestCloudWatchAppender/testBatchExceptionHandling.properties");
-
-        MockCloudWatchClient mockClient = new MockCloudWatchClient()
-        {
-            @Override
-            protected PutLogEventsResult putLogEvents(PutLogEventsRequest request)
-            {
-                throw new TestingException("can't send it");
-            }
-        };
-
-        // note that we will be running the writer on a separate thread
-        appender.setThreadFactory(new DefaultThreadFactory());
-        appender.setWriterFactory(mockClient.newWriterFactory());
-
-        CloudWatchAppenderStatistics appenderStats = appender.getAppenderStatistics();
-
-        // first message triggers writer creation
-
-        logger.debug("message one");
-
-        mockClient.allowWriterThread();
-
-        AbstractLogWriter writer = (AbstractLogWriter)appender.getWriter();
-        MessageQueue messageQueue = ClassUtil.getFieldValue(writer, "messageQueue", MessageQueue.class);
-        Throwable lastError = appenderStats.getLastError();
-
-        assertEquals("putLogEvents called",                     1,                          mockClient.putLogEventsInvocationCount);
-        assertNotNull("writer still exists",                                                writer);
-        assertEquals("stats reports no messages sent",          0,                          appenderStats.getMessagesSent());
-        assertTrue("error message was non-blank",                                           ! appenderStats.getLastErrorMessage().equals(""));
-        assertEquals("exception retained",                      TestingException.class,     lastError.getClass());
-        assertEquals("exception message",                       "can't send it",            lastError.getMessage());
-        assertTrue("message queue still accepts messages",                                  messageQueue.getDiscardThreshold() > 0);
-
-        // the background thread will try to assemble another batch right away, so we can't examine
-        // the message queue; instead we'll wait for the writer to call PutLogEvents again
-
-        mockClient.allowWriterThread();
-
-        assertEquals("putLogEvents called again",               2,                          mockClient.putLogEventsInvocationCount);
-    }
-
-
-    @Test
     public void testUncaughtExceptionHandling() throws Exception
     {
         initialize("TestCloudWatchAppender/testUncaughtExceptionHandling.properties");
@@ -729,234 +422,5 @@ public class TestCloudWatchAppender
 
         assertNull("writer has been reset",         appender.getWriter());
         assertEquals("last writer exception class", TestingException.class, appenderStats.getLastError().getClass());
-    }
-
-
-    @Test
-    public void testMessageErrorHandling() throws Exception
-    {
-        // WARNING: this test may break if the internal implementation changes
-
-        initialize("TestCloudWatchAppender/testMessageErrorHandling.properties");
-
-        // the mock client -- will throw on odd invocations
-        MockCloudWatchClient mockClient = new MockCloudWatchClient()
-        {
-            @Override
-            protected PutLogEventsResult putLogEvents(PutLogEventsRequest request)
-            {
-                if (putLogEventsInvocationCount % 2 == 1)
-                {
-                    throw new TestingException("anything");
-                }
-                else
-                {
-                    return super.putLogEvents(request);
-                }
-            }
-        };
-
-        appender.setThreadFactory(new DefaultThreadFactory());
-        appender.setWriterFactory(mockClient.newWriterFactory());
-
-        for (int ii = 0 ; ii < 10 ; ii++)
-        {
-            logger.debug("message " + ii);
-        }
-
-        mockClient.allowWriterThread();
-
-        assertEquals("first batch, number of events in request", 10, mockClient.mostRecentEvents.size());
-
-        List<InputLogEvent> preservedEvents = new ArrayList<InputLogEvent>(mockClient.mostRecentEvents);
-
-        // the first batch should have been returned to the message queue, in order
-
-        mockClient.allowWriterThread();
-
-        assertEquals("second batch, number of events in request", 10, mockClient.mostRecentEvents.size());
-
-        for (int ii = 0 ; ii < mockClient.mostRecentEvents.size() ; ii++)
-        {
-            assertEquals("event #" + ii, preservedEvents.get(ii), mockClient.mostRecentEvents.get(ii));
-        }
-
-        // now assert that those messages will not be resent
-
-        for (int ii = 100 ; ii < 102 ; ii++)
-        {
-            logger.debug("message " + ii);
-        }
-
-        mockClient.allowWriterThread();
-
-        assertEquals("third batch, number of events in request", 2, mockClient.mostRecentEvents.size());
-    }
-
-
-    @Test
-    public void testDiscardOldest() throws Exception
-    {
-        initialize("TestCloudWatchAppender/testDiscardOldest.properties");
-
-        // this is a dummy client: never actually run the writer thread, but
-        // need to test the real writer
-        MockCloudWatchClient mockClient = new MockCloudWatchClient()
-        {
-            @Override
-            protected PutLogEventsResult putLogEvents(PutLogEventsRequest request)
-            {
-                throw new IllegalStateException("should never be called");
-            }
-        };
-
-        appender.setThreadFactory(new NullThreadFactory());
-        appender.setWriterFactory(mockClient.newWriterFactory());
-
-        for (int ii = 0 ; ii < 20 ; ii++)
-        {
-            logger.debug("message " + ii);
-        }
-
-        MessageQueue messageQueue = ClassUtil.getFieldValue(appender.getWriter(), "messageQueue", MessageQueue.class);
-        List<LogMessage> messages = messageQueue.toList();
-
-        assertEquals("number of messages in queue", 10, messages.size());
-        assertEquals("oldest message", "message 10\n", messages.get(0).getMessage());
-        assertEquals("newest message", "message 19\n", messages.get(9).getMessage());
-    }
-
-
-    @Test
-    public void testDiscardNewest() throws Exception
-    {
-        initialize("TestCloudWatchAppender/testDiscardNewest.properties");
-
-        // this is a dummy client: never actually run the writer thread, but
-        // need to test the real writer
-        MockCloudWatchClient mockClient = new MockCloudWatchClient()
-        {
-            @Override
-            protected PutLogEventsResult putLogEvents(PutLogEventsRequest request)
-            {
-                throw new IllegalStateException("should never be called");
-            }
-        };
-
-        appender.setThreadFactory(new NullThreadFactory());
-        appender.setWriterFactory(mockClient.newWriterFactory());
-
-        for (int ii = 0 ; ii < 20 ; ii++)
-        {
-            logger.debug("message " + ii);
-        }
-
-        MessageQueue messageQueue = ClassUtil.getFieldValue(appender.getWriter(), "messageQueue", MessageQueue.class);
-        List<LogMessage> messages = messageQueue.toList();
-
-        assertEquals("number of messages in queue", 10, messages.size());
-        assertEquals("oldest message", "message 0\n", messages.get(0).getMessage());
-        assertEquals("newest message", "message 9\n", messages.get(9).getMessage());
-    }
-
-
-    @Test
-    public void testDiscardNone() throws Exception
-    {
-        initialize("TestCloudWatchAppender/testDiscardNone.properties");
-
-        // this is a dummy client: we never actually run the writer thread, but
-        // need to test the real writer
-        MockCloudWatchClient mockClient = new MockCloudWatchClient()
-        {
-            @Override
-            protected PutLogEventsResult putLogEvents(PutLogEventsRequest request)
-            {
-                throw new IllegalStateException("should never be called");
-            }
-        };
-
-        appender.setThreadFactory(new NullThreadFactory());
-        appender.setWriterFactory(mockClient.newWriterFactory());
-
-        for (int ii = 0 ; ii < 20 ; ii++)
-        {
-            logger.debug("message " + ii);
-        }
-
-        MessageQueue messageQueue = ClassUtil.getFieldValue(appender.getWriter(), "messageQueue", MessageQueue.class);
-        List<LogMessage> messages = messageQueue.toList();
-
-        assertEquals("number of messages in queue", 20, messages.size());
-        assertEquals("oldest message", "message 0\n", messages.get(0).getMessage());
-        assertEquals("newest message", "message 19\n", messages.get(19).getMessage());
-    }
-
-
-    @Test
-    public void testReconfigureDiscardProperties() throws Exception
-    {
-        initialize("TestCloudWatchAppender/testReconfigureDiscardProperties.properties");
-
-        // another test where we don't actually do anything but need to verify actual writer
-
-        appender.setThreadFactory(new NullThreadFactory());
-        appender.setWriterFactory(new MockCloudWatchClient().newWriterFactory());
-
-        logger.debug("trigger writer creation");
-
-        MessageQueue messageQueue = ClassUtil.getFieldValue(appender.getWriter(), "messageQueue", MessageQueue.class);
-
-        assertEquals("initial discard threshold, from appender",    12345,                              appender.getDiscardThreshold());
-        assertEquals("initial discard action, from appender",       DiscardAction.newest.toString(),    appender.getDiscardAction());
-
-        assertEquals("initial discard threshold, from queue",       12345,                              messageQueue.getDiscardThreshold());
-        assertEquals("initial discard action, from queue",          DiscardAction.newest.toString(),    messageQueue.getDiscardAction().toString());
-
-        appender.setDiscardThreshold(54321);
-        appender.setDiscardAction(DiscardAction.oldest.toString());
-
-        assertEquals("updated discard threshold, from appender",    54321,                              appender.getDiscardThreshold());
-        assertEquals("updated discard action, from appender",       DiscardAction.oldest.toString(),    appender.getDiscardAction());
-
-        assertEquals("updated discard threshold, from queue",       54321,                              messageQueue.getDiscardThreshold());
-        assertEquals("updated discard action, from queue",          DiscardAction.oldest.toString(),    messageQueue.getDiscardAction().toString());
-    }
-
-
-    @Test
-    public void testStaticClientFactory() throws Exception
-    {
-        initialize("TestCloudWatchAppender/testStaticClientFactory.properties");
-
-        appender.setThreadFactory(new DefaultThreadFactory());
-        appender.setWriterFactory(new CloudWatchWriterFactory());
-
-        // first message triggers writer creation
-
-        logger.debug("message one");
-
-        waitForInitialization();
-
-        AbstractLogWriter writer = (AbstractLogWriter)appender.getWriter();
-
-        assertNotNull("factory was called to create client",    staticFactoryMock);
-        assertNull("no initialization message",                 appender.getAppenderStatistics().getLastErrorMessage());
-        assertNull("no initialization error",                   appender.getAppenderStatistics().getLastError());
-        assertEquals("writer called factory method",            "com.kdgregory.log4j.aws.TestCloudWatchAppender.createMockClient",
-                                                                writer.getClientFactoryUsed());
-
-        // at this point we know that the factory was called, but we'll let the client write
-        // the message and use the same asserts as in testWriterWithExistingGroupAndStream()
-
-        staticFactoryMock.allowWriterThread();
-
-        assertEquals("describeLogGroups: invocation count",   2,                staticFactoryMock.describeLogGroupsInvocationCount);
-        assertEquals("describeLogStreams: invocation count",  4,                staticFactoryMock.describeLogStreamsInvocationCount);
-        assertEquals("createLogGroup: invocation count",      0,                staticFactoryMock.createLogGroupInvocationCount);
-        assertEquals("createLogStream: invocation count",     0,                staticFactoryMock.createLogStreamInvocationCount);
-        assertEquals("putLogEvents: invocation count",        1,                staticFactoryMock.putLogEventsInvocationCount);
-        assertEquals("putLogEvents: last call #/messages",    1,                staticFactoryMock.mostRecentEvents.size());
-        assertEquals("putLogEvents: last message",            "message one\n",  staticFactoryMock.mostRecentEvents.get(0).getMessage());
     }
 }

--- a/appenders/src/test/java/com/kdgregory/log4j/aws/TestCloudWatchAppender.java
+++ b/appenders/src/test/java/com/kdgregory/log4j/aws/TestCloudWatchAppender.java
@@ -14,6 +14,7 @@
 
 package com.kdgregory.log4j.aws;
 
+
 import java.net.URL;
 
 import org.junit.After;

--- a/appenders/src/test/java/com/kdgregory/log4j/aws/TestCloudWatchLogWriter.java
+++ b/appenders/src/test/java/com/kdgregory/log4j/aws/TestCloudWatchLogWriter.java
@@ -137,7 +137,6 @@ public class TestCloudWatchLogWriter
 
         MockCloudWatchClient mockClient = new MockCloudWatchClient();
 
-        // TODO: need a new thread factory that creates non-daemon threads
         appender.setThreadFactory(new DefaultThreadFactory());
         appender.setWriterFactory(mockClient.newWriterFactory());
 
@@ -179,7 +178,6 @@ public class TestCloudWatchLogWriter
 
         MockCloudWatchClient mockClient = new MockCloudWatchClient();
 
-        // TODO: need a new thread factory that creates non-daemon threads
         appender.setThreadFactory(new DefaultThreadFactory());
         appender.setWriterFactory(mockClient.newWriterFactory());
 
@@ -225,7 +223,6 @@ public class TestCloudWatchLogWriter
 
         MockCloudWatchClient mockClient = new MockCloudWatchClient();
 
-        // TODO: need a new thread factory that creates non-daemon threads
         appender.setThreadFactory(new DefaultThreadFactory());
         appender.setWriterFactory(mockClient.newWriterFactory());
 
@@ -274,7 +271,6 @@ public class TestCloudWatchLogWriter
 
         MockCloudWatchClient mockClient = new MockCloudWatchClient(MockCloudWatchClient.NAMES, 5, MockCloudWatchClient.NAMES, 5);
 
-        // TODO: need a new thread factory that creates non-daemon threads
         appender.setThreadFactory(new DefaultThreadFactory());
         appender.setWriterFactory(mockClient.newWriterFactory());
 
@@ -315,7 +311,6 @@ public class TestCloudWatchLogWriter
 
         MockCloudWatchClient mockClient = new MockCloudWatchClient();
 
-        // TODO: need a new thread factory that creates non-daemon threads
         appender.setThreadFactory(new DefaultThreadFactory());
         appender.setWriterFactory(mockClient.newWriterFactory());
 
@@ -341,7 +336,6 @@ public class TestCloudWatchLogWriter
 
         MockCloudWatchClient mockClient = new MockCloudWatchClient();
 
-        // TODO: need a new thread factory that creates non-daemon threads
         appender.setThreadFactory(new DefaultThreadFactory());
         appender.setWriterFactory(mockClient.newWriterFactory());
 
@@ -374,7 +368,6 @@ public class TestCloudWatchLogWriter
             }
         };
 
-        // TODO: need a new thread factory that creates non-daemon threads
         appender.setThreadFactory(new DefaultThreadFactory());
         appender.setWriterFactory(mockClient.newWriterFactory());
 
@@ -423,7 +416,6 @@ public class TestCloudWatchLogWriter
             }
         };
 
-        // TODO: need a new thread factory that creates non-daemon threads
         appender.setThreadFactory(new DefaultThreadFactory());
         appender.setWriterFactory(mockClient.newWriterFactory());
 
@@ -480,7 +472,6 @@ public class TestCloudWatchLogWriter
             }
         };
 
-        // TODO: need a new thread factory that creates non-daemon threads
         appender.setThreadFactory(new DefaultThreadFactory());
         appender.setWriterFactory(mockClient.newWriterFactory());
 
@@ -619,7 +610,6 @@ public class TestCloudWatchLogWriter
     {
         initialize("TestCloudWatchAppender/testStaticClientFactory.properties");
 
-        // TODO: need a new thread factory that creates non-daemon threads
         appender.setThreadFactory(new DefaultThreadFactory());
         appender.setWriterFactory(new CloudWatchWriterFactory());
 

--- a/appenders/src/test/java/com/kdgregory/log4j/aws/TestCloudWatchLogWriter.java
+++ b/appenders/src/test/java/com/kdgregory/log4j/aws/TestCloudWatchLogWriter.java
@@ -1,0 +1,610 @@
+// Copyright (c) Keith D Gregory
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.kdgregory.log4j.aws;
+
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+import org.apache.log4j.PropertyConfigurator;
+import org.apache.log4j.helpers.LogLog;
+
+import net.sf.kdgcommons.lang.ClassUtil;
+
+import com.amazonaws.services.logs.AWSLogs;
+import com.amazonaws.services.logs.model.DescribeLogGroupsRequest;
+import com.amazonaws.services.logs.model.DescribeLogGroupsResult;
+import com.amazonaws.services.logs.model.InputLogEvent;
+import com.amazonaws.services.logs.model.PutLogEventsRequest;
+import com.amazonaws.services.logs.model.PutLogEventsResult;
+
+import com.kdgregory.log4j.aws.internal.cloudwatch.CloudWatchAppenderStatistics;
+import com.kdgregory.log4j.aws.internal.cloudwatch.CloudWatchWriterFactory;
+import com.kdgregory.log4j.aws.internal.shared.AbstractLogWriter;
+import com.kdgregory.log4j.aws.internal.shared.DefaultThreadFactory;
+import com.kdgregory.log4j.aws.internal.shared.LogMessage;
+import com.kdgregory.log4j.aws.internal.shared.MessageQueue;
+import com.kdgregory.log4j.aws.internal.shared.MessageQueue.DiscardAction;
+import com.kdgregory.log4j.testhelpers.*;
+import com.kdgregory.log4j.testhelpers.aws.cloudwatch.*;
+
+
+/**
+ *  These tests exercise the interaction between the appender and CloudWatch, via
+ *  an actual writer. To do that, they mock out the CloudWatch client. Most of
+ *  these tests spin up an actual writer thread, so must coordinate interaction
+ *  between that thread and the test (main) thread.
+ */
+public class TestCloudWatchLogWriter
+{
+    private Logger logger;
+    private TestableCloudWatchAppender appender;
+
+
+    private void initialize(String propsName)
+    throws Exception
+    {
+        URL config = ClassLoader.getSystemResource(propsName);
+        assertNotNull("was able to retrieve config", config);
+        PropertyConfigurator.configure(config);
+
+        logger = Logger.getLogger(getClass());
+
+        Logger rootLogger = Logger.getRootLogger();
+        appender = (TestableCloudWatchAppender)rootLogger.getAppender("default");
+
+        appender.setThreadFactory(new InlineThreadFactory());
+        appender.setWriterFactory(new MockCloudWatchWriterFactory(appender));
+    }
+
+
+    /**
+     *  A spin loop that waits for an writer running in another thread to
+     *  finish initialization, either successfully or with error.
+     */
+    private void waitForInitialization() throws Exception
+    {
+        for (int ii = 0 ; ii < 50 ; ii++)
+        {
+            AbstractLogWriter writer = (AbstractLogWriter)appender.getWriter();
+            if ((writer != null) && writer.isInitializationComplete())
+                return;
+            else if (appender.getAppenderStatistics().getLastErrorMessage() != null)
+                return;
+            else
+                Thread.sleep(100);
+        }
+        fail("timed out waiting for initialization");
+    }
+
+
+    // the following variable and function are used by testStaticClientFactory
+
+    private static MockCloudWatchClient staticFactoryMock = null;
+
+    public static AWSLogs createMockClient()
+    {
+        staticFactoryMock = new MockCloudWatchClient();
+        return staticFactoryMock.createClient();
+    }
+
+//----------------------------------------------------------------------------
+//  JUnit stuff
+//----------------------------------------------------------------------------
+
+    @Before
+    public void setUp()
+    {
+        LogManager.resetConfiguration();
+        LogLog.setQuietMode(true);
+    }
+
+
+    @After
+    public void tearDown()
+    {
+        LogLog.setQuietMode(false);
+    }
+
+//----------------------------------------------------------------------------
+//  Tests
+//----------------------------------------------------------------------------
+
+    @Test
+    public void testWriterWithExistingGroupAndStream() throws Exception
+    {
+        initialize("TestCloudWatchAppender/testWriterWithExistingGroupAndStream.properties");
+
+        MockCloudWatchClient mockClient = new MockCloudWatchClient();
+
+        // TODO: need a new thread factory that creates non-daemon threads
+        appender.setThreadFactory(new DefaultThreadFactory());
+        appender.setWriterFactory(mockClient.newWriterFactory());
+
+        logger.debug("message one");
+        mockClient.allowWriterThread();
+
+        // will call describeLogGroups when checking group existence
+        // will call describeLogStreams when checking stream existence, as well as for each putLogEvents
+
+        assertEquals("describeLogGroups: invocation count",   2,                mockClient.describeLogGroupsInvocationCount);
+        assertEquals("describeLogStreams: invocation count",  4,                mockClient.describeLogStreamsInvocationCount);
+        assertEquals("createLogGroup: invocation count",      0,                mockClient.createLogGroupInvocationCount);
+        assertEquals("createLogStream: invocation count",     0,                mockClient.createLogStreamInvocationCount);
+        assertEquals("putLogEvents: invocation count",        1,                mockClient.putLogEventsInvocationCount);
+        assertEquals("putLogEvents: last call #/messages",    1,                mockClient.mostRecentEvents.size());
+        assertEquals("putLogEvents: last message",            "message one\n",  mockClient.mostRecentEvents.get(0).getMessage());
+
+        logger.debug("message two");
+        mockClient.allowWriterThread();
+
+        assertEquals("describeLogGroups: invocation count",   2,                mockClient.describeLogGroupsInvocationCount);
+        assertEquals("describeLogStreams: invocation count",  6,                mockClient.describeLogStreamsInvocationCount);
+        assertEquals("createLogGroup: invocation count",      0,                mockClient.createLogGroupInvocationCount);
+        assertEquals("createLogStream: invocation count",     0,                mockClient.createLogStreamInvocationCount);
+        assertEquals("putLogEvents: invocation count",        2,                mockClient.putLogEventsInvocationCount);
+        assertEquals("putLogEvents: last call #/messages",    1,                mockClient.mostRecentEvents.size());
+        assertEquals("putLogEvents: last message",            "message two\n",  mockClient.mostRecentEvents.get(0).getMessage());
+
+        assertEquals("messages sent, from statistics",          2,              appender.getAppenderStatistics().getMessagesSent());
+        assertEquals("actual log group name, from statistics",  "argle",        appender.getAppenderStatistics().getActualLogGroupName());
+        assertEquals("actual log stream name, from statistics", "bargle",       appender.getAppenderStatistics().getActualLogStreamName());
+    }
+
+
+    @Test
+    public void testWriterWithExistingGroupNewStream() throws Exception
+    {
+        initialize("TestCloudWatchAppender/testWriterWithExistingGroupNewStream.properties");
+
+        MockCloudWatchClient mockClient = new MockCloudWatchClient();
+
+        // TODO: need a new thread factory that creates non-daemon threads
+        appender.setThreadFactory(new DefaultThreadFactory());
+        appender.setWriterFactory(mockClient.newWriterFactory());
+
+        logger.debug("message one");
+        mockClient.allowWriterThread();
+
+        // will call describeLogGroups when checking group existence
+        // will call describeLogStreams before and after creating stream, as well as for each putLogEvents
+
+        assertEquals("describeLogGroups: invocation count",   2,                mockClient.describeLogGroupsInvocationCount);
+        assertEquals("describeLogStreams: invocation count",  6,                mockClient.describeLogStreamsInvocationCount);
+        assertEquals("createLogGroup: invocation count",      0,                mockClient.createLogGroupInvocationCount);
+        assertEquals("createLogStream: invocation count",     1,                mockClient.createLogStreamInvocationCount);
+        assertEquals("createLogStream: group name",           "argle",          mockClient.createLogStreamGroupName);
+        assertEquals("createLogStream: stream name",          "zippy-0",        mockClient.createLogStreamStreamName);
+        assertEquals("putLogEvents: invocation count",        1,                mockClient.putLogEventsInvocationCount);
+        assertEquals("putLogEvents: last call #/messages",    1,                mockClient.mostRecentEvents.size());
+        assertEquals("putLogEvents: last message",            "message one\n",  mockClient.mostRecentEvents.get(0).getMessage());
+
+        logger.debug("message two");
+        mockClient.allowWriterThread();
+
+        assertEquals("describeLogGroups: invocation count",   2,                mockClient.describeLogGroupsInvocationCount);
+        assertEquals("describeLogStreams: invocation count",  8,                mockClient.describeLogStreamsInvocationCount);
+        assertEquals("createLogGroup: invocation count",      0,                mockClient.createLogGroupInvocationCount);
+        assertEquals("createLogStream: invocation count",     1,                mockClient.createLogStreamInvocationCount);
+        assertEquals("createLogStream: group name",           "argle",          mockClient.createLogStreamGroupName);
+        assertEquals("createLogStream: stream name",          "zippy-0",        mockClient.createLogStreamStreamName);
+        assertEquals("putLogEvents: invocation count",        2,                mockClient.putLogEventsInvocationCount);
+        assertEquals("putLogEvents: last call #/messages",    1,                mockClient.mostRecentEvents.size());
+        assertEquals("putLogEvents: last message",            "message two\n",  mockClient.mostRecentEvents.get(0).getMessage());
+
+        assertEquals("messages sent, from statistics",          2,              appender.getAppenderStatistics().getMessagesSent());
+        assertEquals("actual log group name, from statistics",  "argle",        appender.getAppenderStatistics().getActualLogGroupName());
+        assertEquals("actual log stream name, from statistics", "zippy-0",      appender.getAppenderStatistics().getActualLogStreamName());
+    }
+
+
+    @Test
+    public void testWriterWithNewGroupAndStream() throws Exception
+    {
+        initialize("TestCloudWatchAppender/testWriterWithNewGroupAndStream.properties");
+
+        MockCloudWatchClient mockClient = new MockCloudWatchClient();
+
+        // TODO: need a new thread factory that creates non-daemon threads
+        appender.setThreadFactory(new DefaultThreadFactory());
+        appender.setWriterFactory(mockClient.newWriterFactory());
+
+        logger.debug("message one");
+        mockClient.allowWriterThread();
+
+        // will call describeLogGroups both before and after creating group
+        // will call describeLogStreams before and after creating stream, as well as for each putLogEvents
+
+        assertEquals("describeLogGroups: invocation count",   4,                mockClient.describeLogGroupsInvocationCount);
+        assertEquals("describeLogStreams: invocation count",  6,                mockClient.describeLogStreamsInvocationCount);
+        assertEquals("createLogGroup: invocation count",      1,                mockClient.createLogGroupInvocationCount);
+        assertEquals("createLogGroup: group name",            "griffy",         mockClient.createLogGroupGroupName);
+        assertEquals("createLogStream: invocation count",     1,                mockClient.createLogStreamInvocationCount);
+        assertEquals("createLogStream: group name",           "griffy",         mockClient.createLogStreamGroupName);
+        assertEquals("createLogStream: stream name",          "zippy",          mockClient.createLogStreamStreamName);
+        assertEquals("putLogEvents: invocation count",        1,                mockClient.putLogEventsInvocationCount);
+        assertEquals("putLogEvents: last call #/messages",    1,                mockClient.mostRecentEvents.size());
+        assertEquals("putLogEvents: last message",            "message one\n",  mockClient.mostRecentEvents.get(0).getMessage());
+
+        logger.debug("message two");
+        mockClient.allowWriterThread();
+
+        assertEquals("describeLogGroups: invocation count",   4,                mockClient.describeLogGroupsInvocationCount);
+        assertEquals("describeLogStreams: invocation count",  8,                mockClient.describeLogStreamsInvocationCount);
+        assertEquals("createLogGroup: invocation count",      1,                mockClient.createLogGroupInvocationCount);
+        assertEquals("createLogGroup: group name",            "griffy",         mockClient.createLogGroupGroupName);
+        assertEquals("createLogStream: invocation count",     1,                mockClient.createLogStreamInvocationCount);
+        assertEquals("createLogStream: group name",           "griffy",         mockClient.createLogStreamGroupName);
+        assertEquals("createLogStream: stream name",          "zippy",          mockClient.createLogStreamStreamName);
+        assertEquals("putLogEvents: invocation count",        2,                mockClient.putLogEventsInvocationCount);
+        assertEquals("putLogEvents: last call #/messages",    1,                mockClient.mostRecentEvents.size());
+        assertEquals("putLogEvents: last message",            "message two\n",  mockClient.mostRecentEvents.get(0).getMessage());
+
+        assertEquals("messages sent, from statistics",          2,              appender.getAppenderStatistics().getMessagesSent());
+        assertEquals("actual log group name, from statistics",  "griffy",       appender.getAppenderStatistics().getActualLogGroupName());
+        assertEquals("actual log stream name, from statistics", "zippy",        appender.getAppenderStatistics().getActualLogStreamName());
+    }
+
+
+    @Test
+    public void testInvalidGroupName() throws Exception
+    {
+        initialize("TestCloudWatchAppender/testInvalidGroupName.properties");
+
+        MockCloudWatchClient mockClient = new MockCloudWatchClient();
+
+        // TODO: need a new thread factory that creates non-daemon threads
+        appender.setThreadFactory(new DefaultThreadFactory());
+        appender.setWriterFactory(mockClient.newWriterFactory());
+
+        logger.debug("message one");
+
+        waitForInitialization();
+        String initializationMessage = appender.getAppenderStatistics().getLastErrorMessage();
+
+        assertTrue("initialization message indicates invalid group name (was: " + initializationMessage + ")",
+                   initializationMessage.contains("invalid log group name"));
+        assertTrue("initialization message contains invalid name (was: " + initializationMessage + ")",
+                   initializationMessage.contains("helpme!"));
+
+        assertEquals("describeLogGroups: should not be invoked",    0,  mockClient.describeLogGroupsInvocationCount);
+        assertEquals("describeLogStreams: should not be invoked",   0,  mockClient.describeLogStreamsInvocationCount);
+    }
+
+
+    @Test
+    public void testInvalidStreamName() throws Exception
+    {
+        initialize("TestCloudWatchAppender/testInvalidStreamName.properties");
+
+        MockCloudWatchClient mockClient = new MockCloudWatchClient();
+
+        // TODO: need a new thread factory that creates non-daemon threads
+        appender.setThreadFactory(new DefaultThreadFactory());
+        appender.setWriterFactory(mockClient.newWriterFactory());
+
+        logger.debug("message one");
+
+        waitForInitialization();
+        String initializationMessage = appender.getAppenderStatistics().getLastErrorMessage();
+
+        assertTrue("initialization message indicates invalid stream name (was: " + initializationMessage + ")",
+                   initializationMessage.contains("invalid log stream name"));
+        assertTrue("initialization message contains invalid name (was: " + initializationMessage + ")",
+                   initializationMessage.contains("I:Am:Not"));
+
+        assertEquals("describeLogGroups: should not be invoked",    0,  mockClient.describeLogGroupsInvocationCount);
+        assertEquals("describeLogStreams: should not be invoked",   0,  mockClient.describeLogStreamsInvocationCount);
+    }
+
+
+    @Test
+    public void testInitializationErrorHandling() throws Exception
+    {
+        initialize("TestCloudWatchAppender/testInitializationErrorHandling.properties");
+
+        MockCloudWatchClient mockClient = new MockCloudWatchClient()
+        {
+            @Override
+            protected DescribeLogGroupsResult describeLogGroups(DescribeLogGroupsRequest request)
+            {
+                throw new TestingException("not now, not ever");
+            }
+        };
+
+        // TODO: need a new thread factory that creates non-daemon threads
+        appender.setThreadFactory(new DefaultThreadFactory());
+        appender.setWriterFactory(mockClient.newWriterFactory());
+
+        // first message triggers writer creation
+
+        logger.debug("message one");
+
+        waitForInitialization();
+        String initializationMessage = appender.getAppenderStatistics().getLastErrorMessage();
+        Throwable initializationError = appender.getAppenderStatistics().getLastError();
+
+        AbstractLogWriter writer = (AbstractLogWriter)appender.getWriter();
+        MessageQueue messageQueue = ClassUtil.getFieldValue(writer, "messageQueue", MessageQueue.class);
+
+        assertEquals("describeLogGroups: invocation count",     1,                          mockClient.describeLogGroupsInvocationCount);
+        assertEquals("describeLogStreams: invocation count",    0,                          mockClient.describeLogStreamsInvocationCount);
+
+        assertNotNull("writer still exists",                                                writer);
+        assertTrue("initialization message was non-blank",                                  ! initializationMessage.equals(""));
+        assertEquals("initialization exception retained",       TestingException.class,     initializationError.getClass());
+        assertEquals("initialization error message",            "not now, not ever",        initializationError.getMessage());
+
+
+        assertEquals("message queue set to discard all",        0,                          messageQueue.getDiscardThreshold());
+        assertEquals("message queue set to discard all",        DiscardAction.oldest,       messageQueue.getDiscardAction());
+        assertEquals("messages in queue (initial)",             1,                          messageQueue.toList().size());
+
+        // trying to log another message should clear the queue
+
+        logger.info("message two");
+        assertEquals("messages in queue (second try)",          0,                          messageQueue.toList().size());
+    }
+
+
+    @Test
+    public void testBatchExceptionHandling() throws Exception
+    {
+        initialize("TestCloudWatchAppender/testBatchExceptionHandling.properties");
+
+        MockCloudWatchClient mockClient = new MockCloudWatchClient()
+        {
+            @Override
+            protected PutLogEventsResult putLogEvents(PutLogEventsRequest request)
+            {
+                throw new TestingException("can't send it");
+            }
+        };
+
+        // TODO: need a new thread factory that creates non-daemon threads
+        appender.setThreadFactory(new DefaultThreadFactory());
+        appender.setWriterFactory(mockClient.newWriterFactory());
+
+        CloudWatchAppenderStatistics appenderStats = appender.getAppenderStatistics();
+
+        // first message triggers writer creation
+
+        logger.debug("message one");
+
+        mockClient.allowWriterThread();
+
+        AbstractLogWriter writer = (AbstractLogWriter)appender.getWriter();
+        MessageQueue messageQueue = ClassUtil.getFieldValue(writer, "messageQueue", MessageQueue.class);
+        Throwable lastError = appenderStats.getLastError();
+
+        assertEquals("putLogEvents called",                     1,                          mockClient.putLogEventsInvocationCount);
+        assertNotNull("writer still exists",                                                writer);
+        assertEquals("stats reports no messages sent",          0,                          appenderStats.getMessagesSent());
+        assertTrue("error message was non-blank",                                           ! appenderStats.getLastErrorMessage().equals(""));
+        assertEquals("exception retained",                      TestingException.class,     lastError.getClass());
+        assertEquals("exception message",                       "can't send it",            lastError.getMessage());
+        assertTrue("message queue still accepts messages",                                  messageQueue.getDiscardThreshold() > 0);
+
+        // the background thread will try to assemble another batch right away, so we can't examine
+        // the message queue; instead we'll wait for the writer to call PutLogEvents again
+
+        mockClient.allowWriterThread();
+
+        assertEquals("putLogEvents called again",               2,                          mockClient.putLogEventsInvocationCount);
+    }
+
+
+    @Test
+    public void testMessageErrorHandling() throws Exception
+    {
+        // WARNING: this test may break if the internal implementation changes
+
+        initialize("TestCloudWatchAppender/testMessageErrorHandling.properties");
+
+        // the mock client -- will throw on odd invocations
+        MockCloudWatchClient mockClient = new MockCloudWatchClient()
+        {
+            @Override
+            protected PutLogEventsResult putLogEvents(PutLogEventsRequest request)
+            {
+                if (putLogEventsInvocationCount % 2 == 1)
+                {
+                    throw new TestingException("anything");
+                }
+                else
+                {
+                    return super.putLogEvents(request);
+                }
+            }
+        };
+
+        // TODO: need a new thread factory that creates non-daemon threads
+        appender.setThreadFactory(new DefaultThreadFactory());
+        appender.setWriterFactory(mockClient.newWriterFactory());
+
+        for (int ii = 0 ; ii < 10 ; ii++)
+        {
+            logger.debug("message " + ii);
+        }
+
+        mockClient.allowWriterThread();
+
+        assertEquals("first batch, number of events in request", 10, mockClient.mostRecentEvents.size());
+
+        List<InputLogEvent> preservedEvents = new ArrayList<InputLogEvent>(mockClient.mostRecentEvents);
+
+        // the first batch should have been returned to the message queue, in order
+
+        mockClient.allowWriterThread();
+
+        assertEquals("second batch, number of events in request", 10, mockClient.mostRecentEvents.size());
+
+        for (int ii = 0 ; ii < mockClient.mostRecentEvents.size() ; ii++)
+        {
+            assertEquals("event #" + ii, preservedEvents.get(ii), mockClient.mostRecentEvents.get(ii));
+        }
+
+        // now assert that those messages will not be resent
+
+        for (int ii = 100 ; ii < 102 ; ii++)
+        {
+            logger.debug("message " + ii);
+        }
+
+        mockClient.allowWriterThread();
+
+        assertEquals("third batch, number of events in request", 2, mockClient.mostRecentEvents.size());
+    }
+
+
+    @Test
+    public void testDiscardOldest() throws Exception
+    {
+        initialize("TestCloudWatchAppender/testDiscardOldest.properties");
+
+        appender.setThreadFactory(new NullThreadFactory());
+        appender.setWriterFactory(new MockCloudWatchClient().newWriterFactory());
+
+        for (int ii = 0 ; ii < 20 ; ii++)
+        {
+            logger.debug("message " + ii);
+        }
+
+        MessageQueue messageQueue = ClassUtil.getFieldValue(appender.getWriter(), "messageQueue", MessageQueue.class);
+        List<LogMessage> messages = messageQueue.toList();
+
+        assertEquals("number of messages in queue", 10, messages.size());
+        assertEquals("oldest message", "message 10\n", messages.get(0).getMessage());
+        assertEquals("newest message", "message 19\n", messages.get(9).getMessage());
+    }
+
+
+    @Test
+    public void testDiscardNewest() throws Exception
+    {
+        initialize("TestCloudWatchAppender/testDiscardNewest.properties");
+
+        appender.setThreadFactory(new NullThreadFactory());
+        appender.setWriterFactory(new MockCloudWatchClient().newWriterFactory());
+
+        for (int ii = 0 ; ii < 20 ; ii++)
+        {
+            logger.debug("message " + ii);
+        }
+
+        MessageQueue messageQueue = ClassUtil.getFieldValue(appender.getWriter(), "messageQueue", MessageQueue.class);
+        List<LogMessage> messages = messageQueue.toList();
+
+        assertEquals("number of messages in queue", 10, messages.size());
+        assertEquals("oldest message", "message 0\n", messages.get(0).getMessage());
+        assertEquals("newest message", "message 9\n", messages.get(9).getMessage());
+    }
+
+
+    @Test
+    public void testDiscardNone() throws Exception
+    {
+        initialize("TestCloudWatchAppender/testDiscardNone.properties");
+
+        appender.setThreadFactory(new NullThreadFactory());
+        appender.setWriterFactory(new MockCloudWatchClient().newWriterFactory());
+
+        for (int ii = 0 ; ii < 20 ; ii++)
+        {
+            logger.debug("message " + ii);
+        }
+
+        MessageQueue messageQueue = ClassUtil.getFieldValue(appender.getWriter(), "messageQueue", MessageQueue.class);
+        List<LogMessage> messages = messageQueue.toList();
+
+        assertEquals("number of messages in queue", 20, messages.size());
+        assertEquals("oldest message", "message 0\n", messages.get(0).getMessage());
+        assertEquals("newest message", "message 19\n", messages.get(19).getMessage());
+    }
+
+
+    @Test
+    public void testReconfigureDiscardProperties() throws Exception
+    {
+        initialize("TestCloudWatchAppender/testReconfigureDiscardProperties.properties");
+
+        appender.setThreadFactory(new NullThreadFactory());
+        appender.setWriterFactory(new MockCloudWatchClient().newWriterFactory());
+
+        logger.debug("trigger writer creation");
+
+        MessageQueue messageQueue = ClassUtil.getFieldValue(appender.getWriter(), "messageQueue", MessageQueue.class);
+
+        assertEquals("initial discard threshold, from appender",    12345,                              appender.getDiscardThreshold());
+        assertEquals("initial discard action, from appender",       DiscardAction.newest.toString(),    appender.getDiscardAction());
+
+        assertEquals("initial discard threshold, from queue",       12345,                              messageQueue.getDiscardThreshold());
+        assertEquals("initial discard action, from queue",          DiscardAction.newest.toString(),    messageQueue.getDiscardAction().toString());
+
+        appender.setDiscardThreshold(54321);
+        appender.setDiscardAction(DiscardAction.oldest.toString());
+
+        assertEquals("updated discard threshold, from appender",    54321,                              appender.getDiscardThreshold());
+        assertEquals("updated discard action, from appender",       DiscardAction.oldest.toString(),    appender.getDiscardAction());
+
+        assertEquals("updated discard threshold, from queue",       54321,                              messageQueue.getDiscardThreshold());
+        assertEquals("updated discard action, from queue",          DiscardAction.oldest.toString(),    messageQueue.getDiscardAction().toString());
+    }
+
+
+    @Test
+    public void testStaticClientFactory() throws Exception
+    {
+        initialize("TestCloudWatchAppender/testStaticClientFactory.properties");
+
+        // TODO: need a new thread factory that creates non-daemon threads
+        appender.setThreadFactory(new DefaultThreadFactory());
+        appender.setWriterFactory(new CloudWatchWriterFactory());
+
+        // first message triggers writer creation
+
+        logger.debug("message one");
+
+        waitForInitialization();
+
+        AbstractLogWriter writer = (AbstractLogWriter)appender.getWriter();
+
+        assertNotNull("factory was called to create client",    staticFactoryMock);
+        assertNull("no initialization message",                 appender.getAppenderStatistics().getLastErrorMessage());
+        assertNull("no initialization error",                   appender.getAppenderStatistics().getLastError());
+        assertEquals("writer called factory method",            "com.kdgregory.log4j.aws.TestCloudWatchLogWriter.createMockClient",
+                                                                writer.getClientFactoryUsed());
+
+        // at this point we know that the factory was called, but we'll let the client write
+        // the message and use the same asserts as in testWriterWithExistingGroupAndStream()
+
+        staticFactoryMock.allowWriterThread();
+
+        assertEquals("describeLogGroups: invocation count",   2,                staticFactoryMock.describeLogGroupsInvocationCount);
+        assertEquals("describeLogStreams: invocation count",  4,                staticFactoryMock.describeLogStreamsInvocationCount);
+        assertEquals("createLogGroup: invocation count",      0,                staticFactoryMock.createLogGroupInvocationCount);
+        assertEquals("createLogStream: invocation count",     0,                staticFactoryMock.createLogStreamInvocationCount);
+        assertEquals("putLogEvents: invocation count",        1,                staticFactoryMock.putLogEventsInvocationCount);
+        assertEquals("putLogEvents: last call #/messages",    1,                staticFactoryMock.mostRecentEvents.size());
+        assertEquals("putLogEvents: last message",            "message one\n",  staticFactoryMock.mostRecentEvents.get(0).getMessage());
+    }
+}

--- a/appenders/src/test/java/com/kdgregory/log4j/aws/TestCloudWatchLogWriter.java
+++ b/appenders/src/test/java/com/kdgregory/log4j/aws/TestCloudWatchLogWriter.java
@@ -147,8 +147,8 @@ public class TestCloudWatchLogWriter
         // will call describeLogGroups when checking group existence
         // will call describeLogStreams when checking stream existence, as well as for each putLogEvents
 
-        assertEquals("describeLogGroups: invocation count",   2,                mockClient.describeLogGroupsInvocationCount);
-        assertEquals("describeLogStreams: invocation count",  4,                mockClient.describeLogStreamsInvocationCount);
+        assertEquals("describeLogGroups: invocation count",   1,                mockClient.describeLogGroupsInvocationCount);
+        assertEquals("describeLogStreams: invocation count",  2,                mockClient.describeLogStreamsInvocationCount);
         assertEquals("createLogGroup: invocation count",      0,                mockClient.createLogGroupInvocationCount);
         assertEquals("createLogStream: invocation count",     0,                mockClient.createLogStreamInvocationCount);
         assertEquals("putLogEvents: invocation count",        1,                mockClient.putLogEventsInvocationCount);
@@ -158,8 +158,8 @@ public class TestCloudWatchLogWriter
         logger.debug("message two");
         mockClient.allowWriterThread();
 
-        assertEquals("describeLogGroups: invocation count",   2,                mockClient.describeLogGroupsInvocationCount);
-        assertEquals("describeLogStreams: invocation count",  6,                mockClient.describeLogStreamsInvocationCount);
+        assertEquals("describeLogGroups: invocation count",   1,                mockClient.describeLogGroupsInvocationCount);
+        assertEquals("describeLogStreams: invocation count",  3,                mockClient.describeLogStreamsInvocationCount);
         assertEquals("createLogGroup: invocation count",      0,                mockClient.createLogGroupInvocationCount);
         assertEquals("createLogStream: invocation count",     0,                mockClient.createLogStreamInvocationCount);
         assertEquals("putLogEvents: invocation count",        2,                mockClient.putLogEventsInvocationCount);
@@ -189,8 +189,8 @@ public class TestCloudWatchLogWriter
         // will call describeLogGroups when checking group existence
         // will call describeLogStreams before and after creating stream, as well as for each putLogEvents
 
-        assertEquals("describeLogGroups: invocation count",   2,                mockClient.describeLogGroupsInvocationCount);
-        assertEquals("describeLogStreams: invocation count",  6,                mockClient.describeLogStreamsInvocationCount);
+        assertEquals("describeLogGroups: invocation count",   1,                mockClient.describeLogGroupsInvocationCount);
+        assertEquals("describeLogStreams: invocation count",  3,                mockClient.describeLogStreamsInvocationCount);
         assertEquals("createLogGroup: invocation count",      0,                mockClient.createLogGroupInvocationCount);
         assertEquals("createLogStream: invocation count",     1,                mockClient.createLogStreamInvocationCount);
         assertEquals("createLogStream: group name",           "argle",          mockClient.createLogStreamGroupName);
@@ -202,8 +202,8 @@ public class TestCloudWatchLogWriter
         logger.debug("message two");
         mockClient.allowWriterThread();
 
-        assertEquals("describeLogGroups: invocation count",   2,                mockClient.describeLogGroupsInvocationCount);
-        assertEquals("describeLogStreams: invocation count",  8,                mockClient.describeLogStreamsInvocationCount);
+        assertEquals("describeLogGroups: invocation count",   1,                mockClient.describeLogGroupsInvocationCount);
+        assertEquals("describeLogStreams: invocation count",  4,                mockClient.describeLogStreamsInvocationCount);
         assertEquals("createLogGroup: invocation count",      0,                mockClient.createLogGroupInvocationCount);
         assertEquals("createLogStream: invocation count",     1,                mockClient.createLogStreamInvocationCount);
         assertEquals("createLogStream: group name",           "argle",          mockClient.createLogStreamGroupName);
@@ -235,8 +235,8 @@ public class TestCloudWatchLogWriter
         // will call describeLogGroups both before and after creating group
         // will call describeLogStreams before and after creating stream, as well as for each putLogEvents
 
-        assertEquals("describeLogGroups: invocation count",   4,                mockClient.describeLogGroupsInvocationCount);
-        assertEquals("describeLogStreams: invocation count",  6,                mockClient.describeLogStreamsInvocationCount);
+        assertEquals("describeLogGroups: invocation count",   2,                mockClient.describeLogGroupsInvocationCount);
+        assertEquals("describeLogStreams: invocation count",  3,                mockClient.describeLogStreamsInvocationCount);
         assertEquals("createLogGroup: invocation count",      1,                mockClient.createLogGroupInvocationCount);
         assertEquals("createLogGroup: group name",            "griffy",         mockClient.createLogGroupGroupName);
         assertEquals("createLogStream: invocation count",     1,                mockClient.createLogStreamInvocationCount);
@@ -249,8 +249,8 @@ public class TestCloudWatchLogWriter
         logger.debug("message two");
         mockClient.allowWriterThread();
 
-        assertEquals("describeLogGroups: invocation count",   4,                mockClient.describeLogGroupsInvocationCount);
-        assertEquals("describeLogStreams: invocation count",  8,                mockClient.describeLogStreamsInvocationCount);
+        assertEquals("describeLogGroups: invocation count",   2,                mockClient.describeLogGroupsInvocationCount);
+        assertEquals("describeLogStreams: invocation count",  4,                mockClient.describeLogStreamsInvocationCount);
         assertEquals("createLogGroup: invocation count",      1,                mockClient.createLogGroupInvocationCount);
         assertEquals("createLogGroup: group name",            "griffy",         mockClient.createLogGroupGroupName);
         assertEquals("createLogStream: invocation count",     1,                mockClient.createLogStreamInvocationCount);
@@ -600,8 +600,8 @@ public class TestCloudWatchLogWriter
 
         staticFactoryMock.allowWriterThread();
 
-        assertEquals("describeLogGroups: invocation count",   2,                staticFactoryMock.describeLogGroupsInvocationCount);
-        assertEquals("describeLogStreams: invocation count",  4,                staticFactoryMock.describeLogStreamsInvocationCount);
+        assertEquals("describeLogGroups: invocation count",   1,                staticFactoryMock.describeLogGroupsInvocationCount);
+        assertEquals("describeLogStreams: invocation count",  2,                staticFactoryMock.describeLogStreamsInvocationCount);
         assertEquals("createLogGroup: invocation count",      0,                staticFactoryMock.createLogGroupInvocationCount);
         assertEquals("createLogStream: invocation count",     0,                staticFactoryMock.createLogStreamInvocationCount);
         assertEquals("putLogEvents: invocation count",        1,                staticFactoryMock.putLogEventsInvocationCount);

--- a/appenders/src/test/java/com/kdgregory/log4j/aws/TestCloudWatchLogWriter.java
+++ b/appenders/src/test/java/com/kdgregory/log4j/aws/TestCloudWatchLogWriter.java
@@ -14,6 +14,7 @@
 
 package com.kdgregory.log4j.aws;
 
+
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;

--- a/appenders/src/test/java/com/kdgregory/log4j/aws/TestKinesisAppender.java
+++ b/appenders/src/test/java/com/kdgregory/log4j/aws/TestKinesisAppender.java
@@ -14,19 +14,12 @@
 
 package com.kdgregory.log4j.aws;
 
-import static net.sf.kdgcommons.test.StringAsserts.*;
 
 import java.net.URL;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
 
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-
 import static org.junit.Assert.*;
 
 import org.apache.log4j.LogManager;
@@ -34,34 +27,25 @@ import org.apache.log4j.Logger;
 import org.apache.log4j.PropertyConfigurator;
 import org.apache.log4j.helpers.LogLog;
 
-import net.sf.kdgcommons.lang.ClassUtil;
 import net.sf.kdgcommons.lang.StringUtil;
 import net.sf.kdgcommons.test.StringAsserts;
 
-import com.amazonaws.services.kinesis.AmazonKinesis;
-import com.amazonaws.services.kinesis.model.*;
-import com.amazonaws.util.BinaryUtils;
-
 import com.kdgregory.log4j.aws.internal.kinesis.KinesisAppenderStatistics;
-import com.kdgregory.log4j.aws.internal.kinesis.KinesisLogWriter;
 import com.kdgregory.log4j.aws.internal.kinesis.KinesisWriterConfig;
-import com.kdgregory.log4j.aws.internal.kinesis.KinesisWriterFactory;
-import com.kdgregory.log4j.aws.internal.shared.AbstractLogWriter;
 import com.kdgregory.log4j.aws.internal.shared.DefaultThreadFactory;
 import com.kdgregory.log4j.aws.internal.shared.LogMessage;
-import com.kdgregory.log4j.aws.internal.shared.MessageQueue;
-import com.kdgregory.log4j.aws.internal.shared.MessageQueue.DiscardAction;
 import com.kdgregory.log4j.testhelpers.HeaderFooterLayout;
 import com.kdgregory.log4j.testhelpers.InlineThreadFactory;
-import com.kdgregory.log4j.testhelpers.NullThreadFactory;
 import com.kdgregory.log4j.testhelpers.TestingException;
 import com.kdgregory.log4j.testhelpers.ThrowingWriterFactory;
-import com.kdgregory.log4j.testhelpers.aws.kinesis.MockKinesisClient;
 import com.kdgregory.log4j.testhelpers.aws.kinesis.MockKinesisWriter;
 import com.kdgregory.log4j.testhelpers.aws.kinesis.MockKinesisWriterFactory;
 import com.kdgregory.log4j.testhelpers.aws.kinesis.TestableKinesisAppender;
 
-
+/**
+ *  These tests exercise the high-level logic of the appender: configuration
+ *  and interaction with the writer. To do so, it mocks the LogWriter.
+ */
 public class TestKinesisAppender
 {
     private Logger logger;
@@ -84,37 +68,6 @@ public class TestKinesisAppender
         appender.setWriterFactory(new MockKinesisWriterFactory(appender));
     }
 
-
-    /**
-     *  A spin loop that waits for an writer running in another thread to
-     *  finish initialization, either successfully or with error.
-     */
-    private void waitForInitialization() throws Exception
-    {
-        for (int ii = 0 ; ii < 50 ; ii++)
-        {
-            AbstractLogWriter writer = (AbstractLogWriter)appender.getWriter();
-            if ((writer != null) && writer.isInitializationComplete())
-                return;
-            else if (appender.getAppenderStatistics().getLastErrorMessage() != null)
-                return;
-            else
-                Thread.sleep(100);
-        }
-        fail("timed out waiting for initialization");
-    }
-
-
-    // the following variable and function are used by testStaticClientFactory
-
-    private static MockKinesisClient staticFactoryMock = null;
-
-    public static AmazonKinesis createMockClient()
-    {
-        staticFactoryMock = new MockKinesisClient();
-        return staticFactoryMock.createClient();
-    }
-
 //----------------------------------------------------------------------------
 //  JUnit stuff
 //----------------------------------------------------------------------------
@@ -133,7 +86,6 @@ public class TestKinesisAppender
         appender.close();
         LogLog.setQuietMode(false);
     }
-
 
 //----------------------------------------------------------------------------
 //  Tests
@@ -195,8 +147,8 @@ public class TestKinesisAppender
         assertNotNull("after message 1, writer is initialized",                 writer);
         assertEquals("after message 1, calls to writer factory",                1,              writerFactory.invocationCount);
 
-        assertRegex("stream name, with substitutions",                          "argle-\\d+",   writer.streamName);
-        assertRegex("default partition key, after substitutions",               "20\\d{12}",    writer.partitionKey);
+        StringAsserts.assertRegex("stream name, with substitutions",            "argle-\\d+",   writer.streamName);
+        StringAsserts.assertRegex("default partition key, after substitutions", "20\\d{12}",    writer.partitionKey);
         assertEquals("after message 1, number of messages in writer",           1,              writer.messages.size());
 
         logger.error("test with exception", new Exception("this is a test"));
@@ -209,7 +161,7 @@ public class TestKinesisAppender
         LogMessage message1 = writer.messages.get(0);
         assertTrue("message 1 timestamp >= initial timestamp", message1.getTimestamp() >= initialTimestamp);
         assertTrue("message 1 timestamp <= batch timestamp",   message1.getTimestamp() <= finalTimestamp);
-        assertRegex(
+        StringAsserts.assertRegex(
                 "message 1 generally follows layout: " + message1.getMessage(),
                 "20[12][0-9]-.* DEBUG .*TestKinesisAppender .*first message.*",
                 message1.getMessage().trim());
@@ -278,338 +230,6 @@ public class TestKinesisAppender
 
 
     @Test
-    public void testWriterWithExistingStream() throws Exception
-    {
-        initialize("TestKinesisAppender/testWriterWithExistingStream.properties");
-
-        MockKinesisClient mockClient = new MockKinesisClient();
-
-        appender.setThreadFactory(new DefaultThreadFactory());
-        appender.setWriterFactory(mockClient.newWriterFactory());
-
-        logger.debug("example message");
-        mockClient.allowWriterThread();
-
-        assertEquals("describeStream: invocation count",        1,          mockClient.describeStreamInvocationCount);
-        assertEquals("describeStream: stream name",             "argle",    mockClient.describeStreamStreamName);
-        assertEquals("createStream: invocation count",          0,          mockClient.createStreamInvocationCount);
-        assertEquals("putRecords: invocation count",            1,          mockClient.putRecordsInvocationCount);
-        assertEquals("putRecords: source record count",         1,          mockClient.putRecordsSourceRecords.size());
-        assertEquals("putRecords: source record partition key", "bargle",   mockClient.putRecordsSourceRecords.get(0).getPartitionKey());
-        assertEquals("putRecords: source record content",       "example message\n",
-                                                                new String(
-                                                                    BinaryUtils.copyAllBytesFrom(mockClient.putRecordsSourceRecords.get(0).getData()),
-                                                                    "UTF-8"));
-
-        assertEquals("actual stream name, from statistics",     "argle",    appender.getAppenderStatistics().getActualStreamName());
-        assertEquals("sent message count, from statistics",     1,          appender.getAppenderStatistics().getMessagesSent());
-    }
-
-
-    @Test
-    public void testWriterCreatesStream() throws Exception
-    {
-        initialize("TestKinesisAppender/testWriterCreatesStream.properties");
-
-        MockKinesisClient mockClient = new MockKinesisClient();
-
-        appender.setThreadFactory(new DefaultThreadFactory());
-        appender.setWriterFactory(mockClient.newWriterFactory());
-
-        logger.debug("example message");
-        mockClient.allowWriterThread();
-
-        // writer calls describeStream once to see if stream exists, a second time
-        // to verify that it's active -- could perhaps combine those calls?
-
-        assertEquals("describeStream: invocation count",        3,          mockClient.describeStreamInvocationCount);
-        assertEquals("describeStream: stream name",             "foo-0",    mockClient.describeStreamStreamName);
-        assertEquals("createStream: invocation count",          1,          mockClient.createStreamInvocationCount);
-        assertEquals("createStream: stream name",               "foo-0",    mockClient.createStreamStreamName);
-        assertEquals("putRecords: invocation count",            1,          mockClient.putRecordsInvocationCount);
-        assertEquals("putRecords: source record count",         1,          mockClient.putRecordsSourceRecords.size());
-        assertEquals("putRecords: source record partition key", "bar",      mockClient.putRecordsSourceRecords.get(0).getPartitionKey());
-        assertEquals("putRecords: source record content",       "example message\n",
-                                                                new String(
-                                                                    BinaryUtils.copyAllBytesFrom(mockClient.putRecordsSourceRecords.get(0).getData()),
-                                                                    "UTF-8"));
-
-        assertEquals("actual stream name, from statistics",     "foo-0",    appender.getAppenderStatistics().getActualStreamName());
-        assertEquals("sent message count, from statistics",     1,          appender.getAppenderStatistics().getMessagesSent());
-    }
-
-
-    @Test
-    public void testMissingStreamNoAutoCreate() throws Exception
-    {
-        initialize("TestKinesisAppender/testMissingStreamNoAutoCreate.properties");
-
-        MockKinesisClient mockClient = new MockKinesisClient();
-
-        appender.setThreadFactory(new DefaultThreadFactory());
-        appender.setWriterFactory(mockClient.newWriterFactory());
-
-        logger.debug("this triggers writer creation");
-
-        waitForInitialization();
-        String initializationMessage = appender.getAppenderStatistics().getLastErrorMessage();
-
-        assertEquals("describeStream: invocation count", 1, mockClient.describeStreamInvocationCount);
-
-        assertTrue("initialization message indicates invalid stream name (was: " + initializationMessage + ")",
-                   initializationMessage.contains("does not exist"));
-        assertTrue("initialization message contains stream name (was: " + initializationMessage + ")",
-                   initializationMessage.contains("foo"));
-    }
-
-
-    @Test
-    public void testInvalidStreamName() throws Exception
-    {
-        initialize("TestKinesisAppender/testInvalidStreamName.properties");
-
-        MockKinesisClient mockClient = new MockKinesisClient();
-
-        appender.setThreadFactory(new DefaultThreadFactory());
-        appender.setWriterFactory(mockClient.newWriterFactory());
-
-        logger.debug("this triggers writer creation");
-
-        waitForInitialization();
-        String initializationMessage = appender.getAppenderStatistics().getLastErrorMessage();
-
-        assertTrue("initialization message indicates invalid stream name (was: " + initializationMessage + ")",
-                   initializationMessage.contains("invalid stream name"));
-        assertTrue("initialization message contains invalid name (was: " + initializationMessage + ")",
-                   initializationMessage.contains("helpme!"));
-
-        assertEquals("describeStream: should not be invoked", 0, mockClient.describeStreamInvocationCount);
-    }
-
-
-    @Test
-    public void testInvalidPartitionKey() throws Exception
-    {
-        initialize("TestKinesisAppender/testInvalidPartitionKey.properties");
-
-        MockKinesisClient mockClient = new MockKinesisClient();
-
-        appender.setThreadFactory(new DefaultThreadFactory());
-        appender.setWriterFactory(mockClient.newWriterFactory());
-
-        logger.debug("this triggers writer creation");
-
-        waitForInitialization();
-        String initializationMessage = appender.getAppenderStatistics().getLastErrorMessage();
-
-        assertTrue("initialization message indicates invalid partition key (was: " + initializationMessage + ")",
-                   initializationMessage.contains("invalid partition key"));
-
-        assertEquals("describeStream: should not be invoked", 0, mockClient.describeStreamInvocationCount);
-    }
-
-
-    @Test
-    public void testRateLimitedDescribe() throws Exception
-    {
-        initialize("TestKinesisAppender/testRateLimitedDescribe.properties");
-
-        MockKinesisClient mockClient = new MockKinesisClient()
-        {
-            @Override
-            protected DescribeStreamResult describeStream(DescribeStreamRequest request)
-            {
-                if (describeStreamInvocationCount < 3)
-                    throw new LimitExceededException("uh oh!");
-                else
-                    return super.describeStream(request);
-            }
-        };
-
-        appender.setThreadFactory(new DefaultThreadFactory());
-        appender.setWriterFactory(mockClient.newWriterFactory());
-
-        logger.debug("example message");
-        mockClient.allowWriterThread();
-
-        // even with exceptions we should be able to write our message
-
-        assertEquals("describeStream: invocation count",        3,          mockClient.describeStreamInvocationCount);
-        assertEquals("describeStream: stream name",             "argle",    mockClient.describeStreamStreamName);
-        assertEquals("createStream: invocation count",          0,          mockClient.createStreamInvocationCount);
-        assertEquals("putRecords: invocation count",            1,          mockClient.putRecordsInvocationCount);
-        assertEquals("putRecords: source record count",         1,          mockClient.putRecordsSourceRecords.size());
-    }
-
-
-    @Test
-    public void testInitializationErrorHandling() throws Exception
-    {
-        initialize("TestKinesisAppender/testInitializationErrorHandling.properties");
-
-        // the mock client will report an error on every third record
-        MockKinesisClient mockClient = new MockKinesisClient()
-        {
-            @Override
-            protected CreateStreamResult createStream(CreateStreamRequest request)
-            {
-                throw new TestingException("not now, not ever");
-            }
-        };
-
-        appender.setThreadFactory(new DefaultThreadFactory());
-        appender.setWriterFactory(mockClient.newWriterFactory());
-
-        // first message triggers writer creation
-
-        logger.debug("example message");
-
-        waitForInitialization();
-        String initializationMessage = appender.getAppenderStatistics().getLastErrorMessage();
-        Throwable initializationError = appender.getAppenderStatistics().getLastError();
-
-        KinesisLogWriter writer = (KinesisLogWriter)appender.getWriter();
-        MessageQueue messageQueue = ClassUtil.getFieldValue(writer, "messageQueue", MessageQueue.class);
-
-        assertEquals("describeStream: invocation count",    1,          mockClient.describeStreamInvocationCount);
-        assertEquals("describeStream: stream name",         "foo",      mockClient.describeStreamStreamName);
-        assertEquals("createStream: invocation count",      1,          mockClient.createStreamInvocationCount);
-        assertEquals("createStream: stream name",           "foo",      mockClient.createStreamStreamName);
-
-        assertNotNull("writer still exists",                                            writer);
-        assertTrue("initialization message was non-blank",                              ! initializationMessage.equals(""));
-        assertEquals("initialization exception retained",   TestingException.class,     initializationError.getClass());
-        assertEquals("initialization error message",        "not now, not ever",        initializationError.getMessage());
-
-        assertEquals("message queue set to discard all",    0,                          messageQueue.getDiscardThreshold());
-        assertEquals("message queue set to discard all",    DiscardAction.oldest,       messageQueue.getDiscardAction());
-        assertEquals("messages in queue (initial)",         1,                          messageQueue.toList().size());
-
-        // trying to log another message should clear the queue
-
-        logger.info("message two");
-        assertEquals("messages in queue (second try)",      0,                          messageQueue.toList().size());
-    }
-
-
-    @Test
-    public void testMessageErrorHandling() throws Exception
-    {
-        initialize("TestKinesisAppender/testMessageErrorHandling.properties");
-
-        // the mock client will report an error on every third record
-        MockKinesisClient mockClient = new MockKinesisClient()
-        {
-            @Override
-            public PutRecordsResult putRecords(PutRecordsRequest request)
-            {
-                int failedRecordCount = 0;
-                List<PutRecordsResultEntry> resultRecords = new ArrayList<PutRecordsResultEntry>();
-                for (int ii = 0 ; ii < request.getRecords().size() ; ii++)
-                {
-                    PutRecordsResultEntry resultRecord = new PutRecordsResultEntry();
-                    resultRecords.add(resultRecord);
-                    if ((ii % 3) == 1)
-                    {
-                        failedRecordCount++;
-                        resultRecord.setErrorCode("anything, really");
-                    }
-                }
-                return new PutRecordsResult()
-                       .withFailedRecordCount(Integer.valueOf(failedRecordCount))
-                       .withRecords(resultRecords);
-            }
-        };
-
-        appender.setThreadFactory(new DefaultThreadFactory());
-        appender.setWriterFactory(mockClient.newWriterFactory());
-
-        for (int ii = 0 ; ii < 10 ; ii++)
-        {
-            logger.debug("message " + ii);
-        }
-
-        mockClient.allowWriterThread();
-
-        assertEquals("first batch, number of successful messages", 7, mockClient.putRecordsSuccesses.size());
-        assertEquals("first batch, number of failed messages",     3, mockClient.putRecordsFailures.size());
-
-        PutRecordsRequestEntry savedFailure1 = mockClient.putRecordsFailures.get(0);
-        PutRecordsRequestEntry savedFailure2 = mockClient.putRecordsFailures.get(1);
-        PutRecordsRequestEntry savedFailure3 = mockClient.putRecordsFailures.get(2);
-
-        mockClient.allowWriterThread();
-
-        assertEquals("second batch, number of successful messages", 2, mockClient.putRecordsSuccesses.size());
-        assertEquals("second batch, number of failed messages",     1, mockClient.putRecordsFailures.size());
-
-        assertTrue("first failure is now first success",
-                   Arrays.equals(
-                       BinaryUtils.copyAllBytesFrom(savedFailure1.getData()),
-                       BinaryUtils.copyAllBytesFrom(mockClient.putRecordsSuccesses.get(0).getData())));
-        assertTrue("third failure is now second success (second failure failed again)",
-                   Arrays.equals(
-                       BinaryUtils.copyAllBytesFrom(savedFailure3.getData()),
-                       BinaryUtils.copyAllBytesFrom(mockClient.putRecordsSuccesses.get(1).getData())));
-
-
-        mockClient.allowWriterThread();
-
-        assertEquals("third batch, number of successful messages", 1, mockClient.putRecordsSuccesses.size());
-        assertEquals("third batch, number of failed messages",     0, mockClient.putRecordsFailures.size());
-
-        assertTrue("second original failure is now a success",
-                   Arrays.equals(
-                       BinaryUtils.copyAllBytesFrom(savedFailure2.getData()),
-                       BinaryUtils.copyAllBytesFrom(mockClient.putRecordsSuccesses.get(0).getData())));
-    }
-
-
-    @Test
-    public void testBatchErrorHandling() throws Exception
-    {
-        initialize("TestKinesisAppender/testBatchErrorHandling.properties");
-
-        MockKinesisClient mockClient = new MockKinesisClient()
-        {
-            @Override
-            public PutRecordsResult putRecords(PutRecordsRequest request)
-            {
-                throw new TestingException("add more shards!");
-            }
-        };
-
-        appender.setThreadFactory(new DefaultThreadFactory());
-        appender.setWriterFactory(mockClient.newWriterFactory());
-
-        logger.debug("a message");
-
-        mockClient.allowWriterThread();
-
-        AbstractLogWriter writer = (AbstractLogWriter)appender.getWriter();
-        MessageQueue messageQueue = ClassUtil.getFieldValue(writer, "messageQueue", MessageQueue.class);
-        KinesisAppenderStatistics appenderStats = appender.getAppenderStatistics();
-        Throwable lastError = appenderStats.getLastError();
-
-        assertEquals("number of calls to PutRecords",           1,                          mockClient.putRecordsInvocationCount);
-        assertNotNull("writer still exists",                                                writer);
-        assertEquals("stats reports no messages sent",          0,                          appenderStats.getMessagesSent());
-        assertTrue("error message was non-blank",                                           ! appenderStats.getLastErrorMessage().equals(""));
-        assertEquals("exception retained",                      TestingException.class,     lastError.getClass());
-        assertEquals("exception message",                       "add more shards!",         lastError.getMessage());
-        assertTrue("message queue still accepts messages",                                  messageQueue.getDiscardThreshold() > 0);
-
-        // the background thread will try to assemble another batch right away, so we can't examine
-        // the message queue; instead we'll wait for the writer to call PutRecords again
-
-        mockClient.allowWriterThread();
-
-        assertEquals("PutRecords called again",                 2,                          mockClient.putRecordsInvocationCount);
-
-    }
-
-
-    @Test
     public void testUncaughtExceptionHandling() throws Exception
     {
         initialize("TestKinesisAppender/testUncaughtExceptionHandling.properties");
@@ -635,216 +255,5 @@ public class TestKinesisAppender
 
         assertNull("writer has been reset",         appender.getWriter());
         assertEquals("last writer exception class", TestingException.class, appenderStats.getLastError().getClass());
-    }
-
-
-    @Test
-    public void testDiscardOldest() throws Exception
-    {
-        initialize("TestKinesisAppender/testDiscardOldest.properties");
-
-        // this is a dummy client: never actually run the writer thread, but
-        // need to test the real writer
-        MockKinesisClient mockClient = new MockKinesisClient()
-        {
-            @Override
-            public PutRecordsResult putRecords(PutRecordsRequest request)
-            {
-                throw new IllegalStateException("should never be called");
-            }
-        };
-
-        appender.setThreadFactory(new NullThreadFactory());
-        appender.setWriterFactory(mockClient.newWriterFactory());
-
-        for (int ii = 0 ; ii < 20 ; ii++)
-        {
-            logger.debug("message " + ii);
-        }
-
-        KinesisLogWriter writer = (KinesisLogWriter)appender.getWriter();
-        MessageQueue messageQueue = ClassUtil.getFieldValue(writer, "messageQueue", MessageQueue.class);
-        List<LogMessage> messages = messageQueue.toList();
-
-        assertEquals("number of messages in queue", 10, messages.size());
-        assertEquals("oldest message", "message 10\n", messages.get(0).getMessage());
-        assertEquals("newest message", "message 19\n", messages.get(9).getMessage());
-    }
-
-
-    @Test
-    public void testDiscardNewest() throws Exception
-    {
-        initialize("TestKinesisAppender/testDiscardNewest.properties");
-
-        // this is a dummy client: never actually run the writer thread, but
-        // need to test the real writer
-        MockKinesisClient mockClient = new MockKinesisClient()
-        {
-            @Override
-            public PutRecordsResult putRecords(PutRecordsRequest request)
-            {
-                throw new IllegalStateException("should never be called");
-            }
-        };
-
-        appender.setThreadFactory(new NullThreadFactory());
-        appender.setWriterFactory(mockClient.newWriterFactory());
-
-        for (int ii = 0 ; ii < 20 ; ii++)
-        {
-            logger.debug("message " + ii);
-        }
-
-        KinesisLogWriter writer = (KinesisLogWriter)appender.getWriter();
-        MessageQueue messageQueue = ClassUtil.getFieldValue(writer, "messageQueue", MessageQueue.class);
-        List<LogMessage> messages = messageQueue.toList();
-
-        assertEquals("number of messages in queue", 10, messages.size());
-        assertEquals("oldest message", "message 0\n", messages.get(0).getMessage());
-        assertEquals("newest message", "message 9\n", messages.get(9).getMessage());
-    }
-
-
-    @Test
-    public void testDiscardNone() throws Exception
-    {
-        initialize("TestKinesisAppender/testDiscardNone.properties");
-
-        // this is a dummy client: never actually run the writer thread, but
-        // need to test the real writer
-        MockKinesisClient mockClient = new MockKinesisClient()
-        {
-            @Override
-            public PutRecordsResult putRecords(PutRecordsRequest request)
-            {
-                throw new IllegalStateException("should never be called");
-            }
-        };
-
-        appender.setThreadFactory(new NullThreadFactory());
-        appender.setWriterFactory(mockClient.newWriterFactory());
-
-        for (int ii = 0 ; ii < 20 ; ii++)
-        {
-            logger.debug("message " + ii);
-        }
-
-        KinesisLogWriter writer = (KinesisLogWriter)appender.getWriter();
-        MessageQueue messageQueue = ClassUtil.getFieldValue(writer, "messageQueue", MessageQueue.class);
-        List<LogMessage> messages = messageQueue.toList();
-
-        assertEquals("number of messages in queue", 20, messages.size());
-        assertEquals("oldest message", "message 0\n", messages.get(0).getMessage());
-        assertEquals("newest message", "message 19\n", messages.get(19).getMessage());
-    }
-
-
-    @Test
-    public void testReconfigureDiscardProperties() throws Exception
-    {
-        initialize("TestKinesisAppender/testReconfigureDiscardProperties.properties");
-
-        // another test where we don't actually do anything but need to verify actual writer
-
-        appender.setThreadFactory(new NullThreadFactory());
-        appender.setWriterFactory(new MockKinesisClient().newWriterFactory());
-
-        logger.debug("trigger writer creation");
-
-        KinesisLogWriter writer = (KinesisLogWriter)appender.getWriter();
-        MessageQueue messageQueue = ClassUtil.getFieldValue(writer, "messageQueue", MessageQueue.class);
-
-        assertEquals("initial discard threshold, from appender",    12345,                              appender.getDiscardThreshold());
-        assertEquals("initial discard action, from appender",       DiscardAction.newest.toString(),    appender.getDiscardAction());
-
-        assertEquals("initial discard threshold, from queue",       12345,                              messageQueue.getDiscardThreshold());
-        assertEquals("initial discard action, from queue",          DiscardAction.newest.toString(),    messageQueue.getDiscardAction().toString());
-
-        appender.setDiscardThreshold(54321);
-        appender.setDiscardAction(DiscardAction.oldest.toString());
-
-        assertEquals("updated discard threshold, from appender",    54321,                              appender.getDiscardThreshold());
-        assertEquals("updated discard action, from appender",       DiscardAction.oldest.toString(),    appender.getDiscardAction());
-
-        assertEquals("updated discard threshold, from queue",       54321,                              messageQueue.getDiscardThreshold());
-        assertEquals("updated discard action, from queue",          DiscardAction.oldest.toString(),    messageQueue.getDiscardAction().toString());
-    }
-
-
-    @Test
-    public void testStaticClientFactory() throws Exception
-    {
-        initialize("TestKinesisAppender/testStaticClientFactory.properties");
-        appender.setThreadFactory(new DefaultThreadFactory());
-        appender.setWriterFactory(new KinesisWriterFactory());
-
-        // first message triggers writer creation
-
-        logger.debug("example message");
-
-        waitForInitialization();
-
-        AbstractLogWriter writer = (AbstractLogWriter)appender.getWriter();
-
-        assertNotNull("factory was called to create client",    staticFactoryMock);
-        assertNull("no initialization message",                 appender.getAppenderStatistics().getLastErrorMessage());
-        assertNull("no initialization error",                   appender.getAppenderStatistics().getLastError());
-        assertEquals("factory method called",                   "com.kdgregory.log4j.aws.TestKinesisAppender.createMockClient",
-                                                                 writer.getClientFactoryUsed());
-
-        // although we should be happy at this point, we'll actually verify that the
-        // message got written; assertions copied from testWriterWithExistingStream()
-
-        staticFactoryMock.allowWriterThread();
-
-        assertEquals("describeStream: invocation count",        1,          staticFactoryMock.describeStreamInvocationCount);
-        assertEquals("describeStream: stream name",             "argle",    staticFactoryMock.describeStreamStreamName);
-        assertEquals("createStream: invocation count",          0,          staticFactoryMock.createStreamInvocationCount);
-        assertEquals("putRecords: invocation count",            1,          staticFactoryMock.putRecordsInvocationCount);
-        assertEquals("putRecords: source record count",         1,          staticFactoryMock.putRecordsSourceRecords.size());
-        assertEquals("putRecords: source record partition key", "bargle",   staticFactoryMock.putRecordsSourceRecords.get(0).getPartitionKey());
-        assertEquals("putRecords: source record content",       "example message\n",
-                                                                new String(
-                                                                    BinaryUtils.copyAllBytesFrom(staticFactoryMock.putRecordsSourceRecords.get(0).getData()),
-                                                                    "UTF-8"));
-    }
-
-
-    @Test
-    public void testRandomPartitionKey() throws Exception
-    {
-        initialize("TestKinesisAppender/testRandomPartitionKey.properties");
-
-        final Set<String> partitionKeys = new HashSet<String>();
-        MockKinesisClient mockClient = new MockKinesisClient()
-        {
-            @Override
-            protected PutRecordsResult putRecords(PutRecordsRequest request)
-            {
-                for (PutRecordsRequestEntry entry : request.getRecords())
-                {
-                    partitionKeys.add(entry.getPartitionKey());
-                }
-                return super.putRecords(request);
-            }
-        };
-
-        appender.setThreadFactory(new DefaultThreadFactory());
-        appender.setWriterFactory(mockClient.newWriterFactory());
-
-        for (int ii = 0 ; ii < 10 ; ii++)
-        {
-            logger.debug("example message");
-        }
-        mockClient.allowWriterThread();
-
-        // it's possibly but unlikely for this to fail -- we could randomly get same value
-        assertEquals("number of partition keys", 10, partitionKeys.size());
-
-        for (String key : partitionKeys)
-        {
-            StringAsserts.assertRegex("partition key is 8 digits (was: " + key + ")", "\\d{8}", key);
-        }
     }
 }

--- a/appenders/src/test/java/com/kdgregory/log4j/aws/TestKinesisLogWriter.java
+++ b/appenders/src/test/java/com/kdgregory/log4j/aws/TestKinesisLogWriter.java
@@ -1,0 +1,687 @@
+// Copyright (c) Keith D Gregory
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.kdgregory.log4j.aws;
+
+
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+import org.apache.log4j.PropertyConfigurator;
+import org.apache.log4j.helpers.LogLog;
+
+import net.sf.kdgcommons.lang.ClassUtil;
+import net.sf.kdgcommons.test.StringAsserts;
+
+import com.amazonaws.services.kinesis.AmazonKinesis;
+import com.amazonaws.services.kinesis.model.CreateStreamRequest;
+import com.amazonaws.services.kinesis.model.CreateStreamResult;
+import com.amazonaws.services.kinesis.model.DescribeStreamRequest;
+import com.amazonaws.services.kinesis.model.DescribeStreamResult;
+import com.amazonaws.services.kinesis.model.LimitExceededException;
+import com.amazonaws.services.kinesis.model.PutRecordsRequest;
+import com.amazonaws.services.kinesis.model.PutRecordsRequestEntry;
+import com.amazonaws.services.kinesis.model.PutRecordsResult;
+import com.amazonaws.services.kinesis.model.PutRecordsResultEntry;
+import com.amazonaws.util.BinaryUtils;
+
+import com.kdgregory.log4j.aws.internal.kinesis.KinesisAppenderStatistics;
+import com.kdgregory.log4j.aws.internal.kinesis.KinesisLogWriter;
+import com.kdgregory.log4j.aws.internal.kinesis.KinesisWriterFactory;
+import com.kdgregory.log4j.aws.internal.shared.AbstractLogWriter;
+import com.kdgregory.log4j.aws.internal.shared.DefaultThreadFactory;
+import com.kdgregory.log4j.aws.internal.shared.LogMessage;
+import com.kdgregory.log4j.aws.internal.shared.MessageQueue;
+import com.kdgregory.log4j.aws.internal.shared.MessageQueue.DiscardAction;
+import com.kdgregory.log4j.testhelpers.InlineThreadFactory;
+import com.kdgregory.log4j.testhelpers.NullThreadFactory;
+import com.kdgregory.log4j.testhelpers.TestingException;
+import com.kdgregory.log4j.testhelpers.aws.kinesis.MockKinesisClient;
+import com.kdgregory.log4j.testhelpers.aws.kinesis.MockKinesisWriterFactory;
+import com.kdgregory.log4j.testhelpers.aws.kinesis.TestableKinesisAppender;
+
+/**
+ *  These tests exercise the interaction between the appender and CloudWatch, via
+ *  an actual writer. To do that, they mock out the CloudWatch client. Most of
+ *  these tests spin up an actual writer thread, so must coordinate interaction
+ *  between that thread and the test (main) thread.
+ */
+public class TestKinesisLogWriter
+{
+    private Logger logger;
+    private TestableKinesisAppender appender;
+
+
+    private void initialize(String propsName)
+    throws Exception
+    {
+        URL config = ClassLoader.getSystemResource(propsName);
+        assertNotNull("was able to retrieve config", config);
+        PropertyConfigurator.configure(config);
+
+        logger = Logger.getLogger(getClass());
+
+        Logger rootLogger = Logger.getRootLogger();
+        appender = (TestableKinesisAppender)rootLogger.getAppender("default");
+
+        appender.setThreadFactory(new InlineThreadFactory());
+        appender.setWriterFactory(new MockKinesisWriterFactory(appender));
+    }
+
+
+    /**
+     *  A spin loop that waits for an writer running in another thread to
+     *  finish initialization, either successfully or with error.
+     */
+    private void waitForInitialization() throws Exception
+    {
+        for (int ii = 0 ; ii < 50 ; ii++)
+        {
+            AbstractLogWriter writer = (AbstractLogWriter)appender.getWriter();
+            if ((writer != null) && writer.isInitializationComplete())
+                return;
+            else if (appender.getAppenderStatistics().getLastErrorMessage() != null)
+                return;
+            else
+                Thread.sleep(100);
+        }
+        fail("timed out waiting for initialization");
+    }
+
+
+    // the following variable and function are used by testStaticClientFactory
+
+    private static MockKinesisClient staticFactoryMock = null;
+
+    public static AmazonKinesis createMockClient()
+    {
+        staticFactoryMock = new MockKinesisClient();
+        return staticFactoryMock.createClient();
+    }
+
+//----------------------------------------------------------------------------
+//  JUnit stuff
+//----------------------------------------------------------------------------
+
+    @Before
+    public void setUp()
+    {
+        LogManager.resetConfiguration();
+        LogLog.setQuietMode(true);
+    }
+
+
+    @After
+    public void tearDown()
+    {
+        appender.close();
+        LogLog.setQuietMode(false);
+    }
+
+//----------------------------------------------------------------------------
+//  Tests
+//----------------------------------------------------------------------------
+
+    @Test
+    public void testWriterWithExistingStream() throws Exception
+    {
+        initialize("TestKinesisAppender/testWriterWithExistingStream.properties");
+
+        MockKinesisClient mockClient = new MockKinesisClient();
+
+        appender.setThreadFactory(new DefaultThreadFactory());
+        appender.setWriterFactory(mockClient.newWriterFactory());
+
+        logger.debug("example message");
+        mockClient.allowWriterThread();
+
+        assertEquals("describeStream: invocation count",        1,          mockClient.describeStreamInvocationCount);
+        assertEquals("describeStream: stream name",             "argle",    mockClient.describeStreamStreamName);
+        assertEquals("createStream: invocation count",          0,          mockClient.createStreamInvocationCount);
+        assertEquals("putRecords: invocation count",            1,          mockClient.putRecordsInvocationCount);
+        assertEquals("putRecords: source record count",         1,          mockClient.putRecordsSourceRecords.size());
+        assertEquals("putRecords: source record partition key", "bargle",   mockClient.putRecordsSourceRecords.get(0).getPartitionKey());
+        assertEquals("putRecords: source record content",       "example message\n",
+                                                                new String(
+                                                                    BinaryUtils.copyAllBytesFrom(mockClient.putRecordsSourceRecords.get(0).getData()),
+                                                                    "UTF-8"));
+
+        assertEquals("actual stream name, from statistics",     "argle",    appender.getAppenderStatistics().getActualStreamName());
+        assertEquals("sent message count, from statistics",     1,          appender.getAppenderStatistics().getMessagesSent());
+    }
+
+
+    @Test
+    public void testWriterCreatesStream() throws Exception
+    {
+        initialize("TestKinesisAppender/testWriterCreatesStream.properties");
+
+        MockKinesisClient mockClient = new MockKinesisClient();
+
+        appender.setThreadFactory(new DefaultThreadFactory());
+        appender.setWriterFactory(mockClient.newWriterFactory());
+
+        logger.debug("example message");
+        mockClient.allowWriterThread();
+
+        // writer calls describeStream once to see if stream exists, a second time
+        // to verify that it's active -- could perhaps combine those calls?
+
+        assertEquals("describeStream: invocation count",        3,          mockClient.describeStreamInvocationCount);
+        assertEquals("describeStream: stream name",             "foo-0",    mockClient.describeStreamStreamName);
+        assertEquals("createStream: invocation count",          1,          mockClient.createStreamInvocationCount);
+        assertEquals("createStream: stream name",               "foo-0",    mockClient.createStreamStreamName);
+        assertEquals("putRecords: invocation count",            1,          mockClient.putRecordsInvocationCount);
+        assertEquals("putRecords: source record count",         1,          mockClient.putRecordsSourceRecords.size());
+        assertEquals("putRecords: source record partition key", "bar",      mockClient.putRecordsSourceRecords.get(0).getPartitionKey());
+        assertEquals("putRecords: source record content",       "example message\n",
+                                                                new String(
+                                                                    BinaryUtils.copyAllBytesFrom(mockClient.putRecordsSourceRecords.get(0).getData()),
+                                                                    "UTF-8"));
+
+        assertEquals("actual stream name, from statistics",     "foo-0",    appender.getAppenderStatistics().getActualStreamName());
+        assertEquals("sent message count, from statistics",     1,          appender.getAppenderStatistics().getMessagesSent());
+    }
+
+
+    @Test
+    public void testMissingStreamNoAutoCreate() throws Exception
+    {
+        initialize("TestKinesisAppender/testMissingStreamNoAutoCreate.properties");
+
+        MockKinesisClient mockClient = new MockKinesisClient();
+
+        appender.setThreadFactory(new DefaultThreadFactory());
+        appender.setWriterFactory(mockClient.newWriterFactory());
+
+        logger.debug("this triggers writer creation");
+
+        waitForInitialization();
+        String initializationMessage = appender.getAppenderStatistics().getLastErrorMessage();
+
+        assertEquals("describeStream: invocation count", 1, mockClient.describeStreamInvocationCount);
+
+        assertTrue("initialization message indicates invalid stream name (was: " + initializationMessage + ")",
+                   initializationMessage.contains("does not exist"));
+        assertTrue("initialization message contains stream name (was: " + initializationMessage + ")",
+                   initializationMessage.contains("foo"));
+    }
+
+
+    @Test
+    public void testInvalidStreamName() throws Exception
+    {
+        initialize("TestKinesisAppender/testInvalidStreamName.properties");
+
+        MockKinesisClient mockClient = new MockKinesisClient();
+
+        appender.setThreadFactory(new DefaultThreadFactory());
+        appender.setWriterFactory(mockClient.newWriterFactory());
+
+        logger.debug("this triggers writer creation");
+
+        waitForInitialization();
+        String initializationMessage = appender.getAppenderStatistics().getLastErrorMessage();
+
+        assertTrue("initialization message indicates invalid stream name (was: " + initializationMessage + ")",
+                   initializationMessage.contains("invalid stream name"));
+        assertTrue("initialization message contains invalid name (was: " + initializationMessage + ")",
+                   initializationMessage.contains("helpme!"));
+
+        assertEquals("describeStream: should not be invoked", 0, mockClient.describeStreamInvocationCount);
+    }
+
+
+    @Test
+    public void testInvalidPartitionKey() throws Exception
+    {
+        initialize("TestKinesisAppender/testInvalidPartitionKey.properties");
+
+        MockKinesisClient mockClient = new MockKinesisClient();
+
+        appender.setThreadFactory(new DefaultThreadFactory());
+        appender.setWriterFactory(mockClient.newWriterFactory());
+
+        logger.debug("this triggers writer creation");
+
+        waitForInitialization();
+        String initializationMessage = appender.getAppenderStatistics().getLastErrorMessage();
+
+        assertTrue("initialization message indicates invalid partition key (was: " + initializationMessage + ")",
+                   initializationMessage.contains("invalid partition key"));
+
+        assertEquals("describeStream: should not be invoked", 0, mockClient.describeStreamInvocationCount);
+    }
+
+
+    @Test
+    public void testRateLimitedDescribe() throws Exception
+    {
+        initialize("TestKinesisAppender/testRateLimitedDescribe.properties");
+
+        MockKinesisClient mockClient = new MockKinesisClient()
+        {
+            @Override
+            protected DescribeStreamResult describeStream(DescribeStreamRequest request)
+            {
+                if (describeStreamInvocationCount < 3)
+                    throw new LimitExceededException("uh oh!");
+                else
+                    return super.describeStream(request);
+            }
+        };
+
+        appender.setThreadFactory(new DefaultThreadFactory());
+        appender.setWriterFactory(mockClient.newWriterFactory());
+
+        logger.debug("example message");
+        mockClient.allowWriterThread();
+
+        // even with exceptions we should be able to write our message
+
+        assertEquals("describeStream: invocation count",        3,          mockClient.describeStreamInvocationCount);
+        assertEquals("describeStream: stream name",             "argle",    mockClient.describeStreamStreamName);
+        assertEquals("createStream: invocation count",          0,          mockClient.createStreamInvocationCount);
+        assertEquals("putRecords: invocation count",            1,          mockClient.putRecordsInvocationCount);
+        assertEquals("putRecords: source record count",         1,          mockClient.putRecordsSourceRecords.size());
+    }
+
+
+    @Test
+    public void testInitializationErrorHandling() throws Exception
+    {
+        initialize("TestKinesisAppender/testInitializationErrorHandling.properties");
+
+        // the mock client will report an error on every third record
+        MockKinesisClient mockClient = new MockKinesisClient()
+        {
+            @Override
+            protected CreateStreamResult createStream(CreateStreamRequest request)
+            {
+                throw new TestingException("not now, not ever");
+            }
+        };
+
+        appender.setThreadFactory(new DefaultThreadFactory());
+        appender.setWriterFactory(mockClient.newWriterFactory());
+
+        // first message triggers writer creation
+
+        logger.debug("example message");
+
+        waitForInitialization();
+        String initializationMessage = appender.getAppenderStatistics().getLastErrorMessage();
+        Throwable initializationError = appender.getAppenderStatistics().getLastError();
+
+        KinesisLogWriter writer = (KinesisLogWriter)appender.getWriter();
+        MessageQueue messageQueue = ClassUtil.getFieldValue(writer, "messageQueue", MessageQueue.class);
+
+        assertEquals("describeStream: invocation count",    1,          mockClient.describeStreamInvocationCount);
+        assertEquals("describeStream: stream name",         "foo",      mockClient.describeStreamStreamName);
+        assertEquals("createStream: invocation count",      1,          mockClient.createStreamInvocationCount);
+        assertEquals("createStream: stream name",           "foo",      mockClient.createStreamStreamName);
+
+        assertNotNull("writer still exists",                                            writer);
+        assertTrue("initialization message was non-blank",                              ! initializationMessage.equals(""));
+        assertEquals("initialization exception retained",   TestingException.class,     initializationError.getClass());
+        assertEquals("initialization error message",        "not now, not ever",        initializationError.getMessage());
+
+        assertEquals("message queue set to discard all",    0,                          messageQueue.getDiscardThreshold());
+        assertEquals("message queue set to discard all",    DiscardAction.oldest,       messageQueue.getDiscardAction());
+        assertEquals("messages in queue (initial)",         1,                          messageQueue.toList().size());
+
+        // trying to log another message should clear the queue
+
+        logger.info("message two");
+        assertEquals("messages in queue (second try)",      0,                          messageQueue.toList().size());
+    }
+
+
+    @Test
+    public void testMessageErrorHandling() throws Exception
+    {
+        initialize("TestKinesisAppender/testMessageErrorHandling.properties");
+
+        // the mock client will report an error on every third record
+        MockKinesisClient mockClient = new MockKinesisClient()
+        {
+            @Override
+            public PutRecordsResult putRecords(PutRecordsRequest request)
+            {
+                int failedRecordCount = 0;
+                List<PutRecordsResultEntry> resultRecords = new ArrayList<PutRecordsResultEntry>();
+                for (int ii = 0 ; ii < request.getRecords().size() ; ii++)
+                {
+                    PutRecordsResultEntry resultRecord = new PutRecordsResultEntry();
+                    resultRecords.add(resultRecord);
+                    if ((ii % 3) == 1)
+                    {
+                        failedRecordCount++;
+                        resultRecord.setErrorCode("anything, really");
+                    }
+                }
+                return new PutRecordsResult()
+                       .withFailedRecordCount(Integer.valueOf(failedRecordCount))
+                       .withRecords(resultRecords);
+            }
+        };
+
+        appender.setThreadFactory(new DefaultThreadFactory());
+        appender.setWriterFactory(mockClient.newWriterFactory());
+
+        for (int ii = 0 ; ii < 10 ; ii++)
+        {
+            logger.debug("message " + ii);
+        }
+
+        mockClient.allowWriterThread();
+
+        assertEquals("first batch, number of successful messages", 7, mockClient.putRecordsSuccesses.size());
+        assertEquals("first batch, number of failed messages",     3, mockClient.putRecordsFailures.size());
+
+        PutRecordsRequestEntry savedFailure1 = mockClient.putRecordsFailures.get(0);
+        PutRecordsRequestEntry savedFailure2 = mockClient.putRecordsFailures.get(1);
+        PutRecordsRequestEntry savedFailure3 = mockClient.putRecordsFailures.get(2);
+
+        mockClient.allowWriterThread();
+
+        assertEquals("second batch, number of successful messages", 2, mockClient.putRecordsSuccesses.size());
+        assertEquals("second batch, number of failed messages",     1, mockClient.putRecordsFailures.size());
+
+        assertTrue("first failure is now first success",
+                   Arrays.equals(
+                       BinaryUtils.copyAllBytesFrom(savedFailure1.getData()),
+                       BinaryUtils.copyAllBytesFrom(mockClient.putRecordsSuccesses.get(0).getData())));
+        assertTrue("third failure is now second success (second failure failed again)",
+                   Arrays.equals(
+                       BinaryUtils.copyAllBytesFrom(savedFailure3.getData()),
+                       BinaryUtils.copyAllBytesFrom(mockClient.putRecordsSuccesses.get(1).getData())));
+
+
+        mockClient.allowWriterThread();
+
+        assertEquals("third batch, number of successful messages", 1, mockClient.putRecordsSuccesses.size());
+        assertEquals("third batch, number of failed messages",     0, mockClient.putRecordsFailures.size());
+
+        assertTrue("second original failure is now a success",
+                   Arrays.equals(
+                       BinaryUtils.copyAllBytesFrom(savedFailure2.getData()),
+                       BinaryUtils.copyAllBytesFrom(mockClient.putRecordsSuccesses.get(0).getData())));
+    }
+
+
+    @Test
+    public void testBatchErrorHandling() throws Exception
+    {
+        initialize("TestKinesisAppender/testBatchErrorHandling.properties");
+
+        MockKinesisClient mockClient = new MockKinesisClient()
+        {
+            @Override
+            public PutRecordsResult putRecords(PutRecordsRequest request)
+            {
+                throw new TestingException("add more shards!");
+            }
+        };
+
+        appender.setThreadFactory(new DefaultThreadFactory());
+        appender.setWriterFactory(mockClient.newWriterFactory());
+
+        logger.debug("a message");
+
+        mockClient.allowWriterThread();
+
+        AbstractLogWriter writer = (AbstractLogWriter)appender.getWriter();
+        MessageQueue messageQueue = ClassUtil.getFieldValue(writer, "messageQueue", MessageQueue.class);
+        KinesisAppenderStatistics appenderStats = appender.getAppenderStatistics();
+        Throwable lastError = appenderStats.getLastError();
+
+        assertEquals("number of calls to PutRecords",           1,                          mockClient.putRecordsInvocationCount);
+        assertNotNull("writer still exists",                                                writer);
+        assertEquals("stats reports no messages sent",          0,                          appenderStats.getMessagesSent());
+        assertTrue("error message was non-blank",                                           ! appenderStats.getLastErrorMessage().equals(""));
+        assertEquals("exception retained",                      TestingException.class,     lastError.getClass());
+        assertEquals("exception message",                       "add more shards!",         lastError.getMessage());
+        assertTrue("message queue still accepts messages",                                  messageQueue.getDiscardThreshold() > 0);
+
+        // the background thread will try to assemble another batch right away, so we can't examine
+        // the message queue; instead we'll wait for the writer to call PutRecords again
+
+        mockClient.allowWriterThread();
+
+        assertEquals("PutRecords called again",                 2,                          mockClient.putRecordsInvocationCount);
+    }
+
+
+    @Test
+    public void testDiscardOldest() throws Exception
+    {
+        initialize("TestKinesisAppender/testDiscardOldest.properties");
+
+        // this is a dummy client: never actually run the writer thread, but
+        // need to test the real writer
+        MockKinesisClient mockClient = new MockKinesisClient()
+        {
+            @Override
+            public PutRecordsResult putRecords(PutRecordsRequest request)
+            {
+                throw new IllegalStateException("should never be called");
+            }
+        };
+
+        appender.setThreadFactory(new NullThreadFactory());
+        appender.setWriterFactory(mockClient.newWriterFactory());
+
+        for (int ii = 0 ; ii < 20 ; ii++)
+        {
+            logger.debug("message " + ii);
+        }
+
+        KinesisLogWriter writer = (KinesisLogWriter)appender.getWriter();
+        MessageQueue messageQueue = ClassUtil.getFieldValue(writer, "messageQueue", MessageQueue.class);
+        List<LogMessage> messages = messageQueue.toList();
+
+        assertEquals("number of messages in queue", 10, messages.size());
+        assertEquals("oldest message", "message 10\n", messages.get(0).getMessage());
+        assertEquals("newest message", "message 19\n", messages.get(9).getMessage());
+    }
+
+
+    @Test
+    public void testDiscardNewest() throws Exception
+    {
+        initialize("TestKinesisAppender/testDiscardNewest.properties");
+
+        // this is a dummy client: never actually run the writer thread, but
+        // need to test the real writer
+        MockKinesisClient mockClient = new MockKinesisClient()
+        {
+            @Override
+            public PutRecordsResult putRecords(PutRecordsRequest request)
+            {
+                throw new IllegalStateException("should never be called");
+            }
+        };
+
+        appender.setThreadFactory(new NullThreadFactory());
+        appender.setWriterFactory(mockClient.newWriterFactory());
+
+        for (int ii = 0 ; ii < 20 ; ii++)
+        {
+            logger.debug("message " + ii);
+        }
+
+        KinesisLogWriter writer = (KinesisLogWriter)appender.getWriter();
+        MessageQueue messageQueue = ClassUtil.getFieldValue(writer, "messageQueue", MessageQueue.class);
+        List<LogMessage> messages = messageQueue.toList();
+
+        assertEquals("number of messages in queue", 10, messages.size());
+        assertEquals("oldest message", "message 0\n", messages.get(0).getMessage());
+        assertEquals("newest message", "message 9\n", messages.get(9).getMessage());
+    }
+
+
+    @Test
+    public void testDiscardNone() throws Exception
+    {
+        initialize("TestKinesisAppender/testDiscardNone.properties");
+
+        // this is a dummy client: never actually run the writer thread, but
+        // need to test the real writer
+        MockKinesisClient mockClient = new MockKinesisClient()
+        {
+            @Override
+            public PutRecordsResult putRecords(PutRecordsRequest request)
+            {
+                throw new IllegalStateException("should never be called");
+            }
+        };
+
+        appender.setThreadFactory(new NullThreadFactory());
+        appender.setWriterFactory(mockClient.newWriterFactory());
+
+        for (int ii = 0 ; ii < 20 ; ii++)
+        {
+            logger.debug("message " + ii);
+        }
+
+        KinesisLogWriter writer = (KinesisLogWriter)appender.getWriter();
+        MessageQueue messageQueue = ClassUtil.getFieldValue(writer, "messageQueue", MessageQueue.class);
+        List<LogMessage> messages = messageQueue.toList();
+
+        assertEquals("number of messages in queue", 20, messages.size());
+        assertEquals("oldest message", "message 0\n", messages.get(0).getMessage());
+        assertEquals("newest message", "message 19\n", messages.get(19).getMessage());
+    }
+
+
+    @Test
+    public void testReconfigureDiscardProperties() throws Exception
+    {
+        initialize("TestKinesisAppender/testReconfigureDiscardProperties.properties");
+
+        // another test where we don't actually do anything but need to verify actual writer
+
+        appender.setThreadFactory(new NullThreadFactory());
+        appender.setWriterFactory(new MockKinesisClient().newWriterFactory());
+
+        logger.debug("trigger writer creation");
+
+        KinesisLogWriter writer = (KinesisLogWriter)appender.getWriter();
+        MessageQueue messageQueue = ClassUtil.getFieldValue(writer, "messageQueue", MessageQueue.class);
+
+        assertEquals("initial discard threshold, from appender",    12345,                              appender.getDiscardThreshold());
+        assertEquals("initial discard action, from appender",       DiscardAction.newest.toString(),    appender.getDiscardAction());
+
+        assertEquals("initial discard threshold, from queue",       12345,                              messageQueue.getDiscardThreshold());
+        assertEquals("initial discard action, from queue",          DiscardAction.newest.toString(),    messageQueue.getDiscardAction().toString());
+
+        appender.setDiscardThreshold(54321);
+        appender.setDiscardAction(DiscardAction.oldest.toString());
+
+        assertEquals("updated discard threshold, from appender",    54321,                              appender.getDiscardThreshold());
+        assertEquals("updated discard action, from appender",       DiscardAction.oldest.toString(),    appender.getDiscardAction());
+
+        assertEquals("updated discard threshold, from queue",       54321,                              messageQueue.getDiscardThreshold());
+        assertEquals("updated discard action, from queue",          DiscardAction.oldest.toString(),    messageQueue.getDiscardAction().toString());
+    }
+
+
+    @Test
+    public void testStaticClientFactory() throws Exception
+    {
+        initialize("TestKinesisAppender/testStaticClientFactory.properties");
+        appender.setThreadFactory(new DefaultThreadFactory());
+        appender.setWriterFactory(new KinesisWriterFactory());
+
+        // first message triggers writer creation
+
+        logger.debug("example message");
+
+        waitForInitialization();
+
+        AbstractLogWriter writer = (AbstractLogWriter)appender.getWriter();
+
+        assertNotNull("factory was called to create client",    staticFactoryMock);
+        assertNull("no initialization message",                 appender.getAppenderStatistics().getLastErrorMessage());
+        assertNull("no initialization error",                   appender.getAppenderStatistics().getLastError());
+        assertEquals("factory method called",                   "com.kdgregory.log4j.aws.TestKinesisLogWriter.createMockClient",
+                                                                 writer.getClientFactoryUsed());
+
+        // although we should be happy at this point, we'll actually verify that the
+        // message got written; assertions copied from testWriterWithExistingStream()
+
+        staticFactoryMock.allowWriterThread();
+
+        assertEquals("describeStream: invocation count",        1,          staticFactoryMock.describeStreamInvocationCount);
+        assertEquals("describeStream: stream name",             "argle",    staticFactoryMock.describeStreamStreamName);
+        assertEquals("createStream: invocation count",          0,          staticFactoryMock.createStreamInvocationCount);
+        assertEquals("putRecords: invocation count",            1,          staticFactoryMock.putRecordsInvocationCount);
+        assertEquals("putRecords: source record count",         1,          staticFactoryMock.putRecordsSourceRecords.size());
+        assertEquals("putRecords: source record partition key", "bargle",   staticFactoryMock.putRecordsSourceRecords.get(0).getPartitionKey());
+        assertEquals("putRecords: source record content",       "example message\n",
+                                                                new String(
+                                                                    BinaryUtils.copyAllBytesFrom(staticFactoryMock.putRecordsSourceRecords.get(0).getData()),
+                                                                    "UTF-8"));
+    }
+
+
+    @Test
+    public void testRandomPartitionKey() throws Exception
+    {
+        initialize("TestKinesisAppender/testRandomPartitionKey.properties");
+
+        final Set<String> partitionKeys = new HashSet<String>();
+        MockKinesisClient mockClient = new MockKinesisClient()
+        {
+            @Override
+            protected PutRecordsResult putRecords(PutRecordsRequest request)
+            {
+                for (PutRecordsRequestEntry entry : request.getRecords())
+                {
+                    partitionKeys.add(entry.getPartitionKey());
+                }
+                return super.putRecords(request);
+            }
+        };
+
+        appender.setThreadFactory(new DefaultThreadFactory());
+        appender.setWriterFactory(mockClient.newWriterFactory());
+
+        for (int ii = 0 ; ii < 10 ; ii++)
+        {
+            logger.debug("example message");
+        }
+        mockClient.allowWriterThread();
+
+        // it's possibly but unlikely for this to fail -- we could randomly get same value
+        assertEquals("number of partition keys", 10, partitionKeys.size());
+
+        for (String key : partitionKeys)
+        {
+            StringAsserts.assertRegex("partition key is 8 digits (was: " + key + ")", "\\d{8}", key);
+        }
+    }
+}

--- a/appenders/src/test/java/com/kdgregory/log4j/aws/TestSNSAppender.java
+++ b/appenders/src/test/java/com/kdgregory/log4j/aws/TestSNSAppender.java
@@ -14,16 +14,12 @@
 
 package com.kdgregory.log4j.aws;
 
-import static net.sf.kdgcommons.test.StringAsserts.*;
 
 import java.net.URL;
-import java.util.Arrays;
-import java.util.List;
 
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-
 import static org.junit.Assert.*;
 
 import org.apache.log4j.LogManager;
@@ -31,40 +27,27 @@ import org.apache.log4j.Logger;
 import org.apache.log4j.PropertyConfigurator;
 import org.apache.log4j.helpers.LogLog;
 
-import net.sf.kdgcommons.lang.ClassUtil;
 import net.sf.kdgcommons.lang.StringUtil;
+import net.sf.kdgcommons.test.StringAsserts;
 
-import com.amazonaws.services.sns.AmazonSNS;
-import com.amazonaws.services.sns.model.CreateTopicResult;
-import com.amazonaws.services.sns.model.PublishRequest;
-import com.amazonaws.services.sns.model.PublishResult;
-
-import com.kdgregory.log4j.aws.internal.shared.AbstractLogWriter;
 import com.kdgregory.log4j.aws.internal.shared.DefaultThreadFactory;
 import com.kdgregory.log4j.aws.internal.shared.LogMessage;
-import com.kdgregory.log4j.aws.internal.shared.MessageQueue;
-import com.kdgregory.log4j.aws.internal.shared.MessageQueue.DiscardAction;
 import com.kdgregory.log4j.aws.internal.sns.SNSAppenderStatistics;
 import com.kdgregory.log4j.aws.internal.sns.SNSWriterConfig;
-import com.kdgregory.log4j.aws.internal.sns.SNSWriterFactory;
 import com.kdgregory.log4j.testhelpers.HeaderFooterLayout;
 import com.kdgregory.log4j.testhelpers.InlineThreadFactory;
-import com.kdgregory.log4j.testhelpers.NullThreadFactory;
 import com.kdgregory.log4j.testhelpers.TestingException;
 import com.kdgregory.log4j.testhelpers.ThrowingWriterFactory;
-import com.kdgregory.log4j.testhelpers.aws.sns.MockSNSClient;
 import com.kdgregory.log4j.testhelpers.aws.sns.MockSNSWriter;
 import com.kdgregory.log4j.testhelpers.aws.sns.MockSNSWriterFactory;
 import com.kdgregory.log4j.testhelpers.aws.sns.TestableSNSAppender;
 
-
+/**
+ *  These tests exercise the high-level logic of the appender: configuration
+ *  and interaction with the writer. To do so, it mocks the LogWriter.
+ */
 public class TestSNSAppender
 {
-    // the same topic is used for all tests other than substitutions
-    private final static String EXPECTED_NAME = "example";
-    private final static String EXPECTED_ARN = "arn:aws:sns:us-east-1:123456789012:example";
-
-
     private Logger logger;
     private TestableSNSAppender appender;
 
@@ -85,37 +68,6 @@ public class TestSNSAppender
         appender.setWriterFactory(new MockSNSWriterFactory());
     }
 
-
-    /**
-     *  A spin loop that waits for an writer running in another thread to
-     *  finish initialization, either successfully or with error.
-     */
-    private void waitForInitialization() throws Exception
-    {
-        for (int ii = 0 ; ii < 50 ; ii++)
-        {
-            AbstractLogWriter writer = (AbstractLogWriter)appender.getWriter();
-            if ((writer != null) && writer.isInitializationComplete())
-                return;
-            else if (appender.getAppenderStatistics().getLastErrorMessage() != null)
-                return;
-            else
-                Thread.sleep(100);
-        }
-        fail("timed out waiting for initialization");
-    }
-
-
-    // the following variable and function are used by testStaticClientFactory
-
-    private static MockSNSClient staticFactoryMock = null;
-
-    public static AmazonSNS createMockClient()
-    {
-        staticFactoryMock = new MockSNSClient("example", Arrays.asList("argle", "example", "bargle"));
-        return staticFactoryMock.createClient();
-    }
-
 //----------------------------------------------------------------------------
 //  JUnit stuff
 //----------------------------------------------------------------------------
@@ -133,7 +85,6 @@ public class TestSNSAppender
     {
         LogLog.setQuietMode(false);
     }
-
 
 //----------------------------------------------------------------------------
 //  Tests
@@ -188,8 +139,8 @@ public class TestSNSAppender
 
         assertNotNull("after message 1, writer is initialized",         writer);
         assertEquals("after message 1, calls to writer factory",        1,                  writerFactory.invocationCount);
-        assertRegex("topic name",                                       "name-[0-9]{8}",    writer.config.topicName);
-        assertRegex("topic ARN",                                        "arn-[0-9]{8}",     writer.config.topicArn);
+        StringAsserts.assertRegex("topic name",                         "name-[0-9]{8}",    writer.config.topicName);
+        StringAsserts.assertRegex("topic ARN",                          "arn-[0-9]{8}",     writer.config.topicArn);
         assertEquals("last message appended",                           "first message",    writer.lastMessage.getMessage());
         assertEquals("number of messages in writer queue",              1,                  writer.messages.size());
         assertEquals("first message in queue",                          "first message",    writer.messages.get(0).getMessage());
@@ -257,306 +208,6 @@ public class TestSNSAppender
 
 
     @Test
-    public void testWriterOperationByName() throws Exception
-    {
-        initialize("TestSNSAppender/testWriterOperationByName.properties");
-
-        MockSNSClient mockClient = new MockSNSClient("example", Arrays.asList("argle", "example", "bargle"));
-        appender.setWriterFactory(mockClient.newWriterFactory());
-        appender.setThreadFactory(new DefaultThreadFactory());
-
-        logger.info("message one");
-        mockClient.allowWriterThread();
-
-        logger.info("message two");
-        mockClient.allowWriterThread();
-
-        assertNull("no initialization error",                           appender.getAppenderStatistics().getLastError());
-        assertEquals("invocations of listTopics",       1,              mockClient.listTopicsInvocationCount);
-        assertEquals("invocations of createTopic",      0,              mockClient.createTopicInvocationCount);
-        assertEquals("invocations of publish",          2,              mockClient.publishInvocationCount);
-
-        assertEquals("last message published, arn",     EXPECTED_ARN,   mockClient.lastPublishArn);
-        assertEquals("last message published, subject", null,           mockClient.lastPublishSubject);
-        assertEquals("last message published, body",    "message two",  mockClient.lastPublishMessage);
-
-        assertEquals("topic name, from statistics",         EXPECTED_NAME,  appender.getAppenderStatistics().getActualTopicName());
-        assertEquals("topic ARN, from statistics",          EXPECTED_ARN,   appender.getAppenderStatistics().getActualTopicArn());
-        assertEquals("sent message count, from statistics", 2,              appender.getAppenderStatistics().getMessagesSent());
-    }
-
-
-    @Test
-    public void testWriterOperationByNameMultipleTopicLists() throws Exception
-    {
-        initialize("TestSNSAppender/testWriterOperationByName.properties");
-
-        MockSNSClient mockClient = new MockSNSClient("example", Arrays.asList("argle", "example"), Arrays.asList("bargle"));
-        appender.setWriterFactory(mockClient.newWriterFactory());
-        appender.setThreadFactory(new DefaultThreadFactory());
-
-        logger.info("message one");
-        mockClient.allowWriterThread();
-
-        assertNull("no initialization error",                           appender.getAppenderStatistics().getLastError());
-        assertEquals("invocations of listTopics",       2,              mockClient.listTopicsInvocationCount);
-        assertEquals("invocations of createTopic",      0,              mockClient.createTopicInvocationCount);
-        assertEquals("invocations of publish",          1,              mockClient.publishInvocationCount);
-
-        assertEquals("last message published, arn",     EXPECTED_ARN,   mockClient.lastPublishArn);
-        assertEquals("last message published, subject", null,           mockClient.lastPublishSubject);
-        assertEquals("last message published, body",    "message one",  mockClient.lastPublishMessage);
-
-        assertEquals("topic name, from statistics",         EXPECTED_NAME,  appender.getAppenderStatistics().getActualTopicName());
-        assertEquals("topic ARN, from statistics",          EXPECTED_ARN,   appender.getAppenderStatistics().getActualTopicArn());
-        assertEquals("sent message count, from statistics", 1,              appender.getAppenderStatistics().getMessagesSent());
-    }
-
-
-    @Test
-    public void testWriterOperationByNameNoExistingTopic() throws Exception
-    {
-        initialize("TestSNSAppender/testWriterOperationByName.properties");
-
-        MockSNSClient mockClient = new MockSNSClient("example", Arrays.asList("argle", "bargle"));
-        appender.setWriterFactory(mockClient.newWriterFactory());
-        appender.setThreadFactory(new DefaultThreadFactory());
-
-        logger.info("message one");
-        mockClient.allowWriterThread();
-
-        assertNull("no initialization error",                           appender.getAppenderStatistics().getLastError());
-        assertEquals("invocations of listTopics",       1,              mockClient.listTopicsInvocationCount);
-        assertEquals("invocations of createTopic",      1,              mockClient.createTopicInvocationCount);
-        assertEquals("invocations of publish",          1,              mockClient.publishInvocationCount);
-
-        assertEquals("last message published, arn",     EXPECTED_ARN,   mockClient.lastPublishArn);
-        assertEquals("last message published, subject", null,           mockClient.lastPublishSubject);
-        assertEquals("last message published, body",    "message one",  mockClient.lastPublishMessage);
-
-        assertEquals("topic name, from statistics",         EXPECTED_NAME,  appender.getAppenderStatistics().getActualTopicName());
-        assertEquals("topic ARN, from statistics",          EXPECTED_ARN,   appender.getAppenderStatistics().getActualTopicArn());
-        assertEquals("sent message count, from statistics", 1,              appender.getAppenderStatistics().getMessagesSent());
-    }
-
-
-    @Test
-    public void testWriterOperationByArn() throws Exception
-    {
-        initialize("TestSNSAppender/testWriterOperationByArn.properties");
-
-        MockSNSClient mockClient = new MockSNSClient("example", Arrays.asList("argle", "example", "bargle"));
-        appender.setWriterFactory(mockClient.newWriterFactory());
-        appender.setThreadFactory(new DefaultThreadFactory());
-
-        logger.info("message one");
-        mockClient.allowWriterThread();
-
-        logger.info("message two");
-        mockClient.allowWriterThread();
-
-        assertNull("no initialization error",                           appender.getAppenderStatistics().getLastError());
-        assertEquals("invocations of listTopics",       1,              mockClient.listTopicsInvocationCount);
-        assertEquals("invocations of createTopic",      0,              mockClient.createTopicInvocationCount);
-        assertEquals("invocations of publish",          2,              mockClient.publishInvocationCount);
-
-        assertEquals("last message published, arn",     EXPECTED_ARN,   mockClient.lastPublishArn);
-        assertEquals("last message published, subject", null,           mockClient.lastPublishSubject);
-        assertEquals("last message published, body",    "message two",  mockClient.lastPublishMessage);
-
-        assertEquals("topic name, from statistics",         EXPECTED_NAME,  appender.getAppenderStatistics().getActualTopicName());
-        assertEquals("topic ARN, from statistics",          EXPECTED_ARN,   appender.getAppenderStatistics().getActualTopicArn());
-        assertEquals("sent message count, from statistics", 2,              appender.getAppenderStatistics().getMessagesSent());
-    }
-
-
-    @Test
-    public void testWriterOperationByArnMultipleTopicLists() throws Exception
-    {
-        initialize("TestSNSAppender/testWriterOperationByArn.properties");
-
-        MockSNSClient mockClient = new MockSNSClient("example", Arrays.asList("argle", "example"), Arrays.asList("bargle"));
-        appender.setWriterFactory(mockClient.newWriterFactory());
-        appender.setThreadFactory(new DefaultThreadFactory());
-
-        logger.info("message one");
-        mockClient.allowWriterThread();
-
-        assertNull("no initialization error",                           appender.getAppenderStatistics().getLastError());
-        assertEquals("invocations of listTopics",       2,              mockClient.listTopicsInvocationCount);
-        assertEquals("invocations of createTopic",      0,              mockClient.createTopicInvocationCount);
-        assertEquals("invocations of publish",          1,              mockClient.publishInvocationCount);
-
-        assertEquals("last message published, arn",     EXPECTED_ARN,   mockClient.lastPublishArn);
-        assertEquals("last message published, subject", null,           mockClient.lastPublishSubject);
-        assertEquals("last message published, body",    "message one",  mockClient.lastPublishMessage);
-
-        assertEquals("topic name, from statistics",         EXPECTED_NAME,  appender.getAppenderStatistics().getActualTopicName());
-        assertEquals("topic ARN, from statistics",          EXPECTED_ARN,   appender.getAppenderStatistics().getActualTopicArn());
-        assertEquals("sent message count, from statistics", 1,              appender.getAppenderStatistics().getMessagesSent());
-    }
-
-
-    @Test
-    public void testWriterOperationByArnWithNoExistingTopic() throws Exception
-    {
-        initialize("TestSNSAppender/testWriterOperationByArn.properties");
-
-        MockSNSClient mockClient = new MockSNSClient("example", Arrays.asList("argle", "bargle"));
-        appender.setWriterFactory(mockClient.newWriterFactory());
-        appender.setThreadFactory(new DefaultThreadFactory());
-
-        logger.info("message");
-
-        waitForInitialization();
-        String initializationMessage = appender.getAppenderStatistics().getLastErrorMessage();
-
-        assertTrue("initialization error mentions topic name (was: " + initializationMessage + ")",
-                   initializationMessage.contains("example"));
-
-        assertEquals("invocations of listTopics",           1,          mockClient.listTopicsInvocationCount);
-        assertEquals("invocations of createTopic",          0,          mockClient.createTopicInvocationCount);
-        assertEquals("invocations of publish",              0,          mockClient.publishInvocationCount);
-
-        assertEquals("topic name, from statistics",         null,       appender.getAppenderStatistics().getActualTopicName());
-        assertEquals("topic ARN, from statistics",          null,       appender.getAppenderStatistics().getActualTopicArn());
-        assertEquals("sent message count, from statistics", 0,          appender.getAppenderStatistics().getMessagesSent());
-    }
-
-
-    @Test
-    public void testWriterOperationWithSubject() throws Exception
-    {
-        initialize("TestSNSAppender/testWriterOperationWithSubject.properties");
-
-        MockSNSClient mockClient = new MockSNSClient("example", Arrays.asList("argle", "example", "bargle"));
-        appender.setWriterFactory(mockClient.newWriterFactory());
-        appender.setThreadFactory(new DefaultThreadFactory());
-
-        logger.info("message one");
-        mockClient.allowWriterThread();
-
-        assertNull("no initialization error",                           appender.getAppenderStatistics().getLastError());
-        assertEquals("invocations of listTopics",       1,              mockClient.listTopicsInvocationCount);
-        assertEquals("invocations of createTopic",      0,              mockClient.createTopicInvocationCount);
-        assertEquals("invocations of publish",          1,              mockClient.publishInvocationCount);
-
-        assertEquals("last message published, arn",     EXPECTED_ARN,   mockClient.lastPublishArn);
-        assertEquals("last message published, subject", "fribble-0",    mockClient.lastPublishSubject);
-        assertEquals("last message published, body",    "message one",  mockClient.lastPublishMessage);
-    }
-
-
-    @Test
-    public void testExceptionInInitializer() throws Exception
-    {
-        initialize("TestSNSAppender/testWriterOperationByName.properties");
-
-        MockSNSClient mockClient = new MockSNSClient("example", Arrays.asList("argle", "bargle"))
-        {
-            @Override
-            protected CreateTopicResult createTopic(String name)
-            {
-                throw new TestingException("arbitrary failure");
-            }
-        };
-
-        appender.setWriterFactory(mockClient.newWriterFactory());
-        appender.setThreadFactory(new DefaultThreadFactory());
-
-        // first message triggers writer creation
-
-        logger.info("message one");
-
-        waitForInitialization();
-        String initializationMessage = appender.getAppenderStatistics().getLastErrorMessage();
-        Throwable initializationError = appender.getAppenderStatistics().getLastError();
-
-        AbstractLogWriter writer = (AbstractLogWriter)appender.getWriter();
-        MessageQueue messageQueue = ClassUtil.getFieldValue(writer, "messageQueue", MessageQueue.class);
-
-        assertNotNull("writer was retained",                                            writer);
-        assertTrue("initialization message was non-blank",                              ! initializationMessage.equals(""));
-        assertEquals("initialization exception retained",   TestingException.class,     initializationError.getClass());
-        assertEquals("message queue set to discard all",    0,                          messageQueue.getDiscardThreshold());
-        assertEquals("message queue set to discard all",    DiscardAction.oldest,       messageQueue.getDiscardAction());
-        assertEquals("messages in queue (initial)",         1,                          messageQueue.toList().size());
-
-        // trying to log another message should clear the queue
-
-        logger.info("message two");
-        assertEquals("messages in queue (second try)",      0,                          messageQueue.toList().size());
-    }
-
-
-    @Test
-    public void testInvalidTopicName() throws Exception
-    {
-        initialize("TestSNSAppender/testInvalidTopicName.properties");
-
-        MockSNSClient mockClient = new MockSNSClient("example", Arrays.asList("argle", "example", "bargle"));
-        appender.setWriterFactory(mockClient.newWriterFactory());
-        appender.setThreadFactory(new DefaultThreadFactory());
-
-        // first message triggers writer creation
-
-        logger.info("message one");
-
-        waitForInitialization();
-        String initializationMessage = appender.getAppenderStatistics().getLastErrorMessage();
-
-        assertTrue("initialization message includes topic name (was: " + initializationMessage + ")",
-                   initializationMessage.contains("x%$!"));
-
-        assertEquals("invocations of listTopics",       0,              mockClient.listTopicsInvocationCount);
-        assertEquals("invocations of createTopic",      0,              mockClient.createTopicInvocationCount);
-        assertEquals("invocations of publish",          0,              mockClient.publishInvocationCount);
-    }
-
-
-    @Test
-    public void testBatchErrorHandling() throws Exception
-    {
-        initialize("TestSNSAppender/testBatchErrorHandling.properties");
-
-        MockSNSClient mockClient = new MockSNSClient("example", Arrays.asList("argle", "example", "bargle"))
-        {
-            @Override
-            protected PublishResult publish(PublishRequest request)
-            {
-                throw new TestingException("no notifications for you!");
-            }
-        };
-
-        appender.setWriterFactory(mockClient.newWriterFactory());
-        appender.setThreadFactory(new DefaultThreadFactory());
-
-        logger.info("test message");
-        mockClient.allowWriterThread();
-
-        AbstractLogWriter writer = (AbstractLogWriter)appender.getWriter();
-        MessageQueue messageQueue = ClassUtil.getFieldValue(writer, "messageQueue", MessageQueue.class);
-        SNSAppenderStatistics appenderStats = appender.getAppenderStatistics();
-        Throwable lastError = appenderStats.getLastError();
-
-        assertEquals("number of calls to Publish",              1,                          mockClient.publishInvocationCount);
-        assertNotNull("writer still exists",                                                writer);
-        assertEquals("stats reports no messages sent",          0,                          appenderStats.getMessagesSent());
-        assertTrue("error message was non-blank",                                           ! appenderStats.getLastErrorMessage().equals(""));
-        assertEquals("exception retained",                      TestingException.class,     lastError.getClass());
-        assertEquals("exception message",                       "no notifications for you!", lastError.getMessage());
-        assertTrue("message queue still accepts messages",                                  messageQueue.getDiscardThreshold() > 0);
-
-        // the background thread will try to assemble another batch right away, so we can't examine
-        // the message queue; instead we'll wait for the writer to call Publish again
-
-        mockClient.allowWriterThread();
-
-        assertEquals("Publish called again",                 2,                             mockClient.publishInvocationCount);
-    }
-
-
-    @Test
     public void testUncaughtExceptionHandling() throws Exception
     {
         initialize("TestSNSAppender/testUncaughtExceptionHandling.properties");
@@ -582,172 +233,5 @@ public class TestSNSAppender
 
         assertNull("writer has been reset",         appender.getMockWriter());
         assertEquals("last writer exception class", TestingException.class, appenderStats.getLastError().getClass());
-    }
-
-
-    @Test
-    public void testDiscardOldest() throws Exception
-    {
-        initialize("TestSNSAppender/testDiscardOldest.properties");
-
-        // this is a dummy client: never actually run the writer thread, but
-        // need to test the real writer
-        MockSNSClient mockClient = new MockSNSClient("example", Arrays.asList("example"))
-        {
-            @Override
-            protected PublishResult publish(PublishRequest request)
-            {
-                throw new TestingException("this isn't going to work");
-            }
-        };
-
-        appender.setThreadFactory(new NullThreadFactory());
-        appender.setWriterFactory(mockClient.newWriterFactory());
-
-        for (int ii = 0 ; ii < 20 ; ii++)
-        {
-            logger.debug("message " + ii);
-        }
-
-        AbstractLogWriter writer = (AbstractLogWriter)appender.getWriter();
-        MessageQueue messageQueue = ClassUtil.getFieldValue(writer, "messageQueue", MessageQueue.class);
-        List<LogMessage> messages = messageQueue.toList();
-
-        assertEquals("number of messages in queue", 10, messages.size());
-        assertEquals("oldest message", "message 10\n", messages.get(0).getMessage());
-        assertEquals("newest message", "message 19\n", messages.get(9).getMessage());
-    }
-
-
-    @Test
-    public void testDiscardNewest() throws Exception
-    {
-        initialize("TestSNSAppender/testDiscardNewest.properties");
-
-        // this is a dummy client: never actually run the writer thread, but
-        // need to test the real writer
-        MockSNSClient mockClient = new MockSNSClient("example", Arrays.asList("example"))
-        {
-            @Override
-            protected PublishResult publish(PublishRequest request)
-            {
-                throw new TestingException("this isn't going to work");
-            }
-        };
-
-        appender.setThreadFactory(new NullThreadFactory());
-        appender.setWriterFactory(mockClient.newWriterFactory());
-
-        for (int ii = 0 ; ii < 20 ; ii++)
-        {
-            logger.debug("message " + ii);
-        }
-
-        AbstractLogWriter writer = (AbstractLogWriter)appender.getWriter();
-        MessageQueue messageQueue = ClassUtil.getFieldValue(writer, "messageQueue", MessageQueue.class);
-        List<LogMessage> messages = messageQueue.toList();
-
-        assertEquals("number of messages in queue", 10, messages.size());
-        assertEquals("oldest message", "message 0\n", messages.get(0).getMessage());
-        assertEquals("newest message", "message 9\n", messages.get(9).getMessage());
-    }
-
-
-    @Test
-    public void testDiscardNone() throws Exception
-    {
-        initialize("TestSNSAppender/testDiscardNone.properties");
-
-        // this is a dummy client: we never actually run the writer thread, but
-        // need to test the real writer
-        MockSNSClient mockClient = new MockSNSClient("example", Arrays.asList("example"))
-        {
-            @Override
-            protected PublishResult publish(PublishRequest request)
-            {
-                throw new TestingException("this isn't going to work");
-            }
-        };
-
-        appender.setThreadFactory(new NullThreadFactory());
-        appender.setWriterFactory(mockClient.newWriterFactory());
-
-        for (int ii = 0 ; ii < 20 ; ii++)
-        {
-            logger.debug("message " + ii);
-        }
-
-        AbstractLogWriter writer = (AbstractLogWriter)appender.getWriter();
-        MessageQueue messageQueue = ClassUtil.getFieldValue(writer, "messageQueue", MessageQueue.class);
-        List<LogMessage> messages = messageQueue.toList();
-
-        assertEquals("number of messages in queue", 20, messages.size());
-        assertEquals("oldest message", "message 0\n", messages.get(0).getMessage());
-        assertEquals("newest message", "message 19\n", messages.get(19).getMessage());
-    }
-
-
-    @Test
-    public void testReconfigureDiscardProperties() throws Exception
-    {
-        initialize("TestSNSAppender/testReconfigureDiscardProperties.properties");
-
-        // another test where we don't actually do anything but need to verify actual writer
-
-        appender.setThreadFactory(new NullThreadFactory());
-        appender.setWriterFactory(new MockSNSClient("example", Arrays.asList("example")).newWriterFactory());
-
-        logger.debug("trigger writer creation");
-
-        AbstractLogWriter writer = (AbstractLogWriter)appender.getWriter();
-        MessageQueue messageQueue = ClassUtil.getFieldValue(writer, "messageQueue", MessageQueue.class);
-
-        assertEquals("initial discard threshold, from appender",    12345,                              appender.getDiscardThreshold());
-        assertEquals("initial discard action, from appender",       DiscardAction.newest.toString(),    appender.getDiscardAction());
-
-        assertEquals("initial discard threshold, from queue",       12345,                              messageQueue.getDiscardThreshold());
-        assertEquals("initial discard action, from queue",          DiscardAction.newest.toString(),    messageQueue.getDiscardAction().toString());
-
-        appender.setDiscardThreshold(54321);
-        appender.setDiscardAction(DiscardAction.oldest.toString());
-
-        assertEquals("updated discard threshold, from appender",    54321,                              appender.getDiscardThreshold());
-        assertEquals("updated discard action, from appender",       DiscardAction.oldest.toString(),    appender.getDiscardAction());
-
-        assertEquals("updated discard threshold, from queue",       54321,                              messageQueue.getDiscardThreshold());
-        assertEquals("updated discard action, from queue",          DiscardAction.oldest.toString(),    messageQueue.getDiscardAction().toString());
-    }
-
-
-    @Test
-    public void testStaticClientFactory() throws Exception
-    {
-        initialize("TestSNSAppender/testStaticClientFactory.properties");
-
-        appender.setThreadFactory(new DefaultThreadFactory());
-        appender.setWriterFactory(new SNSWriterFactory());
-
-        logger.info("message one");
-        waitForInitialization();
-
-        AbstractLogWriter writer = (AbstractLogWriter)appender.getWriter();
-
-        assertNotNull("factory was called to create client",    staticFactoryMock);
-        assertNull("no initialization message",                 appender.getAppenderStatistics().getLastErrorMessage());
-        assertNull("no initialization error",                   appender.getAppenderStatistics().getLastError());
-        assertEquals("called explicit client factory",          "com.kdgregory.log4j.aws.TestSNSAppender.createMockClient",
-                                                                writer.getClientFactoryUsed());
-
-        // this should be a sufficient assertion, but we'll go on and let the message get written
-
-        staticFactoryMock.allowWriterThread();
-
-        assertEquals("invocations of listTopics",       1,              staticFactoryMock.listTopicsInvocationCount);
-        assertEquals("invocations of createTopic",      0,              staticFactoryMock.createTopicInvocationCount);
-        assertEquals("invocations of publish",          1,              staticFactoryMock.publishInvocationCount);
-
-        assertEquals("last message published, arn",     EXPECTED_ARN,   staticFactoryMock.lastPublishArn);
-        assertEquals("last message published, subject", null,           staticFactoryMock.lastPublishSubject);
-        assertEquals("last message published, body",    "message one",  staticFactoryMock.lastPublishMessage);
     }
 }

--- a/appenders/src/test/java/com/kdgregory/log4j/aws/TestSNSLogWriter.java
+++ b/appenders/src/test/java/com/kdgregory/log4j/aws/TestSNSLogWriter.java
@@ -1,0 +1,605 @@
+// Copyright (c) Keith D Gregory
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.kdgregory.log4j.aws;
+
+
+import java.net.URL;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+import org.apache.log4j.PropertyConfigurator;
+import org.apache.log4j.helpers.LogLog;
+
+import net.sf.kdgcommons.lang.ClassUtil;
+
+import com.amazonaws.services.sns.AmazonSNS;
+import com.amazonaws.services.sns.model.CreateTopicResult;
+import com.amazonaws.services.sns.model.PublishRequest;
+import com.amazonaws.services.sns.model.PublishResult;
+
+import com.kdgregory.log4j.aws.internal.shared.AbstractLogWriter;
+import com.kdgregory.log4j.aws.internal.shared.DefaultThreadFactory;
+import com.kdgregory.log4j.aws.internal.shared.LogMessage;
+import com.kdgregory.log4j.aws.internal.shared.MessageQueue;
+import com.kdgregory.log4j.aws.internal.shared.MessageQueue.DiscardAction;
+import com.kdgregory.log4j.aws.internal.sns.SNSAppenderStatistics;
+import com.kdgregory.log4j.aws.internal.sns.SNSWriterFactory;
+import com.kdgregory.log4j.testhelpers.InlineThreadFactory;
+import com.kdgregory.log4j.testhelpers.NullThreadFactory;
+import com.kdgregory.log4j.testhelpers.TestingException;
+import com.kdgregory.log4j.testhelpers.aws.sns.MockSNSClient;
+import com.kdgregory.log4j.testhelpers.aws.sns.MockSNSWriterFactory;
+import com.kdgregory.log4j.testhelpers.aws.sns.TestableSNSAppender;
+
+
+/**
+ *  These tests exercise the interaction between the appender and CloudWatch, via
+ *  an actual writer. To do that, they mock out the CloudWatch client. Most of
+ *  these tests spin up an actual writer thread, so must coordinate interaction
+ *  between that thread and the test (main) thread.
+ */
+public class TestSNSLogWriter
+{
+    // the same topic is used for all tests other than substitutions
+    private final static String EXPECTED_NAME = "example";
+    private final static String EXPECTED_ARN = "arn:aws:sns:us-east-1:123456789012:example";
+
+
+    private Logger logger;
+    private TestableSNSAppender appender;
+
+
+    private void initialize(String propsName)
+    throws Exception
+    {
+        URL config = ClassLoader.getSystemResource(propsName);
+        assertNotNull("was able to retrieve config", config);
+        PropertyConfigurator.configure(config);
+
+        logger = Logger.getLogger(getClass());
+
+        Logger rootLogger = Logger.getRootLogger();
+        appender = (TestableSNSAppender)rootLogger.getAppender("default");
+
+        appender.setThreadFactory(new InlineThreadFactory());
+        appender.setWriterFactory(new MockSNSWriterFactory());
+    }
+
+
+    /**
+     *  A spin loop that waits for an writer running in another thread to
+     *  finish initialization, either successfully or with error.
+     */
+    private void waitForInitialization() throws Exception
+    {
+        for (int ii = 0 ; ii < 50 ; ii++)
+        {
+            AbstractLogWriter writer = (AbstractLogWriter)appender.getWriter();
+            if ((writer != null) && writer.isInitializationComplete())
+                return;
+            else if (appender.getAppenderStatistics().getLastErrorMessage() != null)
+                return;
+            else
+                Thread.sleep(100);
+        }
+        fail("timed out waiting for initialization");
+    }
+
+
+    // the following variable and function are used by testStaticClientFactory
+
+    private static MockSNSClient staticFactoryMock = null;
+
+    public static AmazonSNS createMockClient()
+    {
+        staticFactoryMock = new MockSNSClient("example", Arrays.asList("argle", "example", "bargle"));
+        return staticFactoryMock.createClient();
+    }
+
+//----------------------------------------------------------------------------
+//  JUnit stuff
+//----------------------------------------------------------------------------
+
+    @Before
+    public void setUp()
+    {
+        LogManager.resetConfiguration();
+        LogLog.setQuietMode(true);
+    }
+
+
+    @After
+    public void tearDown()
+    {
+        LogLog.setQuietMode(false);
+    }
+
+//----------------------------------------------------------------------------
+//  Tests
+//----------------------------------------------------------------------------
+
+    @Test
+    public void testWriterOperationByName() throws Exception
+    {
+        initialize("TestSNSAppender/testWriterOperationByName.properties");
+
+        MockSNSClient mockClient = new MockSNSClient("example", Arrays.asList("argle", "example", "bargle"));
+        appender.setWriterFactory(mockClient.newWriterFactory());
+        appender.setThreadFactory(new DefaultThreadFactory());
+
+        logger.info("message one");
+        mockClient.allowWriterThread();
+
+        logger.info("message two");
+        mockClient.allowWriterThread();
+
+        assertNull("no initialization error",                           appender.getAppenderStatistics().getLastError());
+        assertEquals("invocations of listTopics",       1,              mockClient.listTopicsInvocationCount);
+        assertEquals("invocations of createTopic",      0,              mockClient.createTopicInvocationCount);
+        assertEquals("invocations of publish",          2,              mockClient.publishInvocationCount);
+
+        assertEquals("last message published, arn",     EXPECTED_ARN,   mockClient.lastPublishArn);
+        assertEquals("last message published, subject", null,           mockClient.lastPublishSubject);
+        assertEquals("last message published, body",    "message two",  mockClient.lastPublishMessage);
+
+        assertEquals("topic name, from statistics",         EXPECTED_NAME,  appender.getAppenderStatistics().getActualTopicName());
+        assertEquals("topic ARN, from statistics",          EXPECTED_ARN,   appender.getAppenderStatistics().getActualTopicArn());
+        assertEquals("sent message count, from statistics", 2,              appender.getAppenderStatistics().getMessagesSent());
+    }
+
+
+    @Test
+    public void testWriterOperationByNameMultipleTopicLists() throws Exception
+    {
+        initialize("TestSNSAppender/testWriterOperationByName.properties");
+
+        MockSNSClient mockClient = new MockSNSClient("example", Arrays.asList("argle", "example"), Arrays.asList("bargle"));
+        appender.setWriterFactory(mockClient.newWriterFactory());
+        appender.setThreadFactory(new DefaultThreadFactory());
+
+        logger.info("message one");
+        mockClient.allowWriterThread();
+
+        assertNull("no initialization error",                           appender.getAppenderStatistics().getLastError());
+        assertEquals("invocations of listTopics",       2,              mockClient.listTopicsInvocationCount);
+        assertEquals("invocations of createTopic",      0,              mockClient.createTopicInvocationCount);
+        assertEquals("invocations of publish",          1,              mockClient.publishInvocationCount);
+
+        assertEquals("last message published, arn",     EXPECTED_ARN,   mockClient.lastPublishArn);
+        assertEquals("last message published, subject", null,           mockClient.lastPublishSubject);
+        assertEquals("last message published, body",    "message one",  mockClient.lastPublishMessage);
+
+        assertEquals("topic name, from statistics",         EXPECTED_NAME,  appender.getAppenderStatistics().getActualTopicName());
+        assertEquals("topic ARN, from statistics",          EXPECTED_ARN,   appender.getAppenderStatistics().getActualTopicArn());
+        assertEquals("sent message count, from statistics", 1,              appender.getAppenderStatistics().getMessagesSent());
+    }
+
+
+    @Test
+    public void testWriterOperationByNameNoExistingTopic() throws Exception
+    {
+        initialize("TestSNSAppender/testWriterOperationByName.properties");
+
+        MockSNSClient mockClient = new MockSNSClient("example", Arrays.asList("argle", "bargle"));
+        appender.setWriterFactory(mockClient.newWriterFactory());
+        appender.setThreadFactory(new DefaultThreadFactory());
+
+        logger.info("message one");
+        mockClient.allowWriterThread();
+
+        assertNull("no initialization error",                           appender.getAppenderStatistics().getLastError());
+        assertEquals("invocations of listTopics",       1,              mockClient.listTopicsInvocationCount);
+        assertEquals("invocations of createTopic",      1,              mockClient.createTopicInvocationCount);
+        assertEquals("invocations of publish",          1,              mockClient.publishInvocationCount);
+
+        assertEquals("last message published, arn",     EXPECTED_ARN,   mockClient.lastPublishArn);
+        assertEquals("last message published, subject", null,           mockClient.lastPublishSubject);
+        assertEquals("last message published, body",    "message one",  mockClient.lastPublishMessage);
+
+        assertEquals("topic name, from statistics",         EXPECTED_NAME,  appender.getAppenderStatistics().getActualTopicName());
+        assertEquals("topic ARN, from statistics",          EXPECTED_ARN,   appender.getAppenderStatistics().getActualTopicArn());
+        assertEquals("sent message count, from statistics", 1,              appender.getAppenderStatistics().getMessagesSent());
+    }
+
+
+    @Test
+    public void testWriterOperationByArn() throws Exception
+    {
+        initialize("TestSNSAppender/testWriterOperationByArn.properties");
+
+        MockSNSClient mockClient = new MockSNSClient("example", Arrays.asList("argle", "example", "bargle"));
+        appender.setWriterFactory(mockClient.newWriterFactory());
+        appender.setThreadFactory(new DefaultThreadFactory());
+
+        logger.info("message one");
+        mockClient.allowWriterThread();
+
+        logger.info("message two");
+        mockClient.allowWriterThread();
+
+        assertNull("no initialization error",                           appender.getAppenderStatistics().getLastError());
+        assertEquals("invocations of listTopics",       1,              mockClient.listTopicsInvocationCount);
+        assertEquals("invocations of createTopic",      0,              mockClient.createTopicInvocationCount);
+        assertEquals("invocations of publish",          2,              mockClient.publishInvocationCount);
+
+        assertEquals("last message published, arn",     EXPECTED_ARN,   mockClient.lastPublishArn);
+        assertEquals("last message published, subject", null,           mockClient.lastPublishSubject);
+        assertEquals("last message published, body",    "message two",  mockClient.lastPublishMessage);
+
+        assertEquals("topic name, from statistics",         EXPECTED_NAME,  appender.getAppenderStatistics().getActualTopicName());
+        assertEquals("topic ARN, from statistics",          EXPECTED_ARN,   appender.getAppenderStatistics().getActualTopicArn());
+        assertEquals("sent message count, from statistics", 2,              appender.getAppenderStatistics().getMessagesSent());
+    }
+
+
+    @Test
+    public void testWriterOperationByArnMultipleTopicLists() throws Exception
+    {
+        initialize("TestSNSAppender/testWriterOperationByArn.properties");
+
+        MockSNSClient mockClient = new MockSNSClient("example", Arrays.asList("argle", "example"), Arrays.asList("bargle"));
+        appender.setWriterFactory(mockClient.newWriterFactory());
+        appender.setThreadFactory(new DefaultThreadFactory());
+
+        logger.info("message one");
+        mockClient.allowWriterThread();
+
+        assertNull("no initialization error",                           appender.getAppenderStatistics().getLastError());
+        assertEquals("invocations of listTopics",       2,              mockClient.listTopicsInvocationCount);
+        assertEquals("invocations of createTopic",      0,              mockClient.createTopicInvocationCount);
+        assertEquals("invocations of publish",          1,              mockClient.publishInvocationCount);
+
+        assertEquals("last message published, arn",     EXPECTED_ARN,   mockClient.lastPublishArn);
+        assertEquals("last message published, subject", null,           mockClient.lastPublishSubject);
+        assertEquals("last message published, body",    "message one",  mockClient.lastPublishMessage);
+
+        assertEquals("topic name, from statistics",         EXPECTED_NAME,  appender.getAppenderStatistics().getActualTopicName());
+        assertEquals("topic ARN, from statistics",          EXPECTED_ARN,   appender.getAppenderStatistics().getActualTopicArn());
+        assertEquals("sent message count, from statistics", 1,              appender.getAppenderStatistics().getMessagesSent());
+    }
+
+
+    @Test
+    public void testWriterOperationByArnWithNoExistingTopic() throws Exception
+    {
+        initialize("TestSNSAppender/testWriterOperationByArn.properties");
+
+        MockSNSClient mockClient = new MockSNSClient("example", Arrays.asList("argle", "bargle"));
+        appender.setWriterFactory(mockClient.newWriterFactory());
+        appender.setThreadFactory(new DefaultThreadFactory());
+
+        logger.info("message");
+
+        waitForInitialization();
+        String initializationMessage = appender.getAppenderStatistics().getLastErrorMessage();
+
+        assertTrue("initialization error mentions topic name (was: " + initializationMessage + ")",
+                   initializationMessage.contains("example"));
+
+        assertEquals("invocations of listTopics",           1,          mockClient.listTopicsInvocationCount);
+        assertEquals("invocations of createTopic",          0,          mockClient.createTopicInvocationCount);
+        assertEquals("invocations of publish",              0,          mockClient.publishInvocationCount);
+
+        assertEquals("topic name, from statistics",         null,       appender.getAppenderStatistics().getActualTopicName());
+        assertEquals("topic ARN, from statistics",          null,       appender.getAppenderStatistics().getActualTopicArn());
+        assertEquals("sent message count, from statistics", 0,          appender.getAppenderStatistics().getMessagesSent());
+    }
+
+
+    @Test
+    public void testWriterOperationWithSubject() throws Exception
+    {
+        initialize("TestSNSAppender/testWriterOperationWithSubject.properties");
+
+        MockSNSClient mockClient = new MockSNSClient("example", Arrays.asList("argle", "example", "bargle"));
+        appender.setWriterFactory(mockClient.newWriterFactory());
+        appender.setThreadFactory(new DefaultThreadFactory());
+
+        logger.info("message one");
+        mockClient.allowWriterThread();
+
+        assertNull("no initialization error",                           appender.getAppenderStatistics().getLastError());
+        assertEquals("invocations of listTopics",       1,              mockClient.listTopicsInvocationCount);
+        assertEquals("invocations of createTopic",      0,              mockClient.createTopicInvocationCount);
+        assertEquals("invocations of publish",          1,              mockClient.publishInvocationCount);
+
+        assertEquals("last message published, arn",     EXPECTED_ARN,   mockClient.lastPublishArn);
+        assertEquals("last message published, subject", "fribble-0",    mockClient.lastPublishSubject);
+        assertEquals("last message published, body",    "message one",  mockClient.lastPublishMessage);
+    }
+
+
+    @Test
+    public void testExceptionInInitializer() throws Exception
+    {
+        initialize("TestSNSAppender/testWriterOperationByName.properties");
+
+        MockSNSClient mockClient = new MockSNSClient("example", Arrays.asList("argle", "bargle"))
+        {
+            @Override
+            protected CreateTopicResult createTopic(String name)
+            {
+                throw new TestingException("arbitrary failure");
+            }
+        };
+
+        appender.setWriterFactory(mockClient.newWriterFactory());
+        appender.setThreadFactory(new DefaultThreadFactory());
+
+        // first message triggers writer creation
+
+        logger.info("message one");
+
+        waitForInitialization();
+        String initializationMessage = appender.getAppenderStatistics().getLastErrorMessage();
+        Throwable initializationError = appender.getAppenderStatistics().getLastError();
+
+        AbstractLogWriter writer = (AbstractLogWriter)appender.getWriter();
+        MessageQueue messageQueue = ClassUtil.getFieldValue(writer, "messageQueue", MessageQueue.class);
+
+        assertNotNull("writer was retained",                                            writer);
+        assertTrue("initialization message was non-blank",                              ! initializationMessage.equals(""));
+        assertEquals("initialization exception retained",   TestingException.class,     initializationError.getClass());
+        assertEquals("message queue set to discard all",    0,                          messageQueue.getDiscardThreshold());
+        assertEquals("message queue set to discard all",    DiscardAction.oldest,       messageQueue.getDiscardAction());
+        assertEquals("messages in queue (initial)",         1,                          messageQueue.toList().size());
+
+        // trying to log another message should clear the queue
+
+        logger.info("message two");
+        assertEquals("messages in queue (second try)",      0,                          messageQueue.toList().size());
+    }
+
+
+    @Test
+    public void testInvalidTopicName() throws Exception
+    {
+        initialize("TestSNSAppender/testInvalidTopicName.properties");
+
+        MockSNSClient mockClient = new MockSNSClient("example", Arrays.asList("argle", "example", "bargle"));
+        appender.setWriterFactory(mockClient.newWriterFactory());
+        appender.setThreadFactory(new DefaultThreadFactory());
+
+        // first message triggers writer creation
+
+        logger.info("message one");
+
+        waitForInitialization();
+        String initializationMessage = appender.getAppenderStatistics().getLastErrorMessage();
+
+        assertTrue("initialization message includes topic name (was: " + initializationMessage + ")",
+                   initializationMessage.contains("x%$!"));
+
+        assertEquals("invocations of listTopics",       0,              mockClient.listTopicsInvocationCount);
+        assertEquals("invocations of createTopic",      0,              mockClient.createTopicInvocationCount);
+        assertEquals("invocations of publish",          0,              mockClient.publishInvocationCount);
+    }
+
+
+    @Test
+    public void testBatchErrorHandling() throws Exception
+    {
+        initialize("TestSNSAppender/testBatchErrorHandling.properties");
+
+        MockSNSClient mockClient = new MockSNSClient("example", Arrays.asList("argle", "example", "bargle"))
+        {
+            @Override
+            protected PublishResult publish(PublishRequest request)
+            {
+                throw new TestingException("no notifications for you!");
+            }
+        };
+
+        appender.setWriterFactory(mockClient.newWriterFactory());
+        appender.setThreadFactory(new DefaultThreadFactory());
+
+        logger.info("test message");
+        mockClient.allowWriterThread();
+
+        AbstractLogWriter writer = (AbstractLogWriter)appender.getWriter();
+        MessageQueue messageQueue = ClassUtil.getFieldValue(writer, "messageQueue", MessageQueue.class);
+        SNSAppenderStatistics appenderStats = appender.getAppenderStatistics();
+        Throwable lastError = appenderStats.getLastError();
+
+        assertEquals("number of calls to Publish",              1,                          mockClient.publishInvocationCount);
+        assertNotNull("writer still exists",                                                writer);
+        assertEquals("stats reports no messages sent",          0,                          appenderStats.getMessagesSent());
+        assertTrue("error message was non-blank",                                           ! appenderStats.getLastErrorMessage().equals(""));
+        assertEquals("exception retained",                      TestingException.class,     lastError.getClass());
+        assertEquals("exception message",                       "no notifications for you!", lastError.getMessage());
+        assertTrue("message queue still accepts messages",                                  messageQueue.getDiscardThreshold() > 0);
+
+        // the background thread will try to assemble another batch right away, so we can't examine
+        // the message queue; instead we'll wait for the writer to call Publish again
+
+        mockClient.allowWriterThread();
+
+        assertEquals("Publish called again",                 2,                             mockClient.publishInvocationCount);
+    }
+
+
+    @Test
+    public void testDiscardOldest() throws Exception
+    {
+        initialize("TestSNSAppender/testDiscardOldest.properties");
+
+        // this is a dummy client: never actually run the writer thread, but
+        // need to test the real writer
+        MockSNSClient mockClient = new MockSNSClient("example", Arrays.asList("example"))
+        {
+            @Override
+            protected PublishResult publish(PublishRequest request)
+            {
+                throw new TestingException("this isn't going to work");
+            }
+        };
+
+        appender.setThreadFactory(new NullThreadFactory());
+        appender.setWriterFactory(mockClient.newWriterFactory());
+
+        for (int ii = 0 ; ii < 20 ; ii++)
+        {
+            logger.debug("message " + ii);
+        }
+
+        AbstractLogWriter writer = (AbstractLogWriter)appender.getWriter();
+        MessageQueue messageQueue = ClassUtil.getFieldValue(writer, "messageQueue", MessageQueue.class);
+        List<LogMessage> messages = messageQueue.toList();
+
+        assertEquals("number of messages in queue", 10, messages.size());
+        assertEquals("oldest message", "message 10\n", messages.get(0).getMessage());
+        assertEquals("newest message", "message 19\n", messages.get(9).getMessage());
+    }
+
+
+    @Test
+    public void testDiscardNewest() throws Exception
+    {
+        initialize("TestSNSAppender/testDiscardNewest.properties");
+
+        // this is a dummy client: never actually run the writer thread, but
+        // need to test the real writer
+        MockSNSClient mockClient = new MockSNSClient("example", Arrays.asList("example"))
+        {
+            @Override
+            protected PublishResult publish(PublishRequest request)
+            {
+                throw new TestingException("this isn't going to work");
+            }
+        };
+
+        appender.setThreadFactory(new NullThreadFactory());
+        appender.setWriterFactory(mockClient.newWriterFactory());
+
+        for (int ii = 0 ; ii < 20 ; ii++)
+        {
+            logger.debug("message " + ii);
+        }
+
+        AbstractLogWriter writer = (AbstractLogWriter)appender.getWriter();
+        MessageQueue messageQueue = ClassUtil.getFieldValue(writer, "messageQueue", MessageQueue.class);
+        List<LogMessage> messages = messageQueue.toList();
+
+        assertEquals("number of messages in queue", 10, messages.size());
+        assertEquals("oldest message", "message 0\n", messages.get(0).getMessage());
+        assertEquals("newest message", "message 9\n", messages.get(9).getMessage());
+    }
+
+
+    @Test
+    public void testDiscardNone() throws Exception
+    {
+        initialize("TestSNSAppender/testDiscardNone.properties");
+
+        // this is a dummy client: we never actually run the writer thread, but
+        // need to test the real writer
+        MockSNSClient mockClient = new MockSNSClient("example", Arrays.asList("example"))
+        {
+            @Override
+            protected PublishResult publish(PublishRequest request)
+            {
+                throw new TestingException("this isn't going to work");
+            }
+        };
+
+        appender.setThreadFactory(new NullThreadFactory());
+        appender.setWriterFactory(mockClient.newWriterFactory());
+
+        for (int ii = 0 ; ii < 20 ; ii++)
+        {
+            logger.debug("message " + ii);
+        }
+
+        AbstractLogWriter writer = (AbstractLogWriter)appender.getWriter();
+        MessageQueue messageQueue = ClassUtil.getFieldValue(writer, "messageQueue", MessageQueue.class);
+        List<LogMessage> messages = messageQueue.toList();
+
+        assertEquals("number of messages in queue", 20, messages.size());
+        assertEquals("oldest message", "message 0\n", messages.get(0).getMessage());
+        assertEquals("newest message", "message 19\n", messages.get(19).getMessage());
+    }
+
+
+    @Test
+    public void testReconfigureDiscardProperties() throws Exception
+    {
+        initialize("TestSNSAppender/testReconfigureDiscardProperties.properties");
+
+        // another test where we don't actually do anything but need to verify actual writer
+
+        appender.setThreadFactory(new NullThreadFactory());
+        appender.setWriterFactory(new MockSNSClient("example", Arrays.asList("example")).newWriterFactory());
+
+        logger.debug("trigger writer creation");
+
+        AbstractLogWriter writer = (AbstractLogWriter)appender.getWriter();
+        MessageQueue messageQueue = ClassUtil.getFieldValue(writer, "messageQueue", MessageQueue.class);
+
+        assertEquals("initial discard threshold, from appender",    12345,                              appender.getDiscardThreshold());
+        assertEquals("initial discard action, from appender",       DiscardAction.newest.toString(),    appender.getDiscardAction());
+
+        assertEquals("initial discard threshold, from queue",       12345,                              messageQueue.getDiscardThreshold());
+        assertEquals("initial discard action, from queue",          DiscardAction.newest.toString(),    messageQueue.getDiscardAction().toString());
+
+        appender.setDiscardThreshold(54321);
+        appender.setDiscardAction(DiscardAction.oldest.toString());
+
+        assertEquals("updated discard threshold, from appender",    54321,                              appender.getDiscardThreshold());
+        assertEquals("updated discard action, from appender",       DiscardAction.oldest.toString(),    appender.getDiscardAction());
+
+        assertEquals("updated discard threshold, from queue",       54321,                              messageQueue.getDiscardThreshold());
+        assertEquals("updated discard action, from queue",          DiscardAction.oldest.toString(),    messageQueue.getDiscardAction().toString());
+    }
+
+
+    @Test
+    public void testStaticClientFactory() throws Exception
+    {
+        initialize("TestSNSAppender/testStaticClientFactory.properties");
+
+        appender.setThreadFactory(new DefaultThreadFactory());
+        appender.setWriterFactory(new SNSWriterFactory());
+
+        logger.info("message one");
+        waitForInitialization();
+
+        AbstractLogWriter writer = (AbstractLogWriter)appender.getWriter();
+
+        assertNotNull("factory was called to create client",    staticFactoryMock);
+        assertNull("no initialization message",                 appender.getAppenderStatistics().getLastErrorMessage());
+        assertNull("no initialization error",                   appender.getAppenderStatistics().getLastError());
+        assertEquals("called explicit client factory",          "com.kdgregory.log4j.aws.TestSNSLogWriter.createMockClient",
+                                                                writer.getClientFactoryUsed());
+
+        // this should be a sufficient assertion, but we'll go on and let the message get written
+
+        staticFactoryMock.allowWriterThread();
+
+        assertEquals("invocations of listTopics",       1,              staticFactoryMock.listTopicsInvocationCount);
+        assertEquals("invocations of createTopic",      0,              staticFactoryMock.createTopicInvocationCount);
+        assertEquals("invocations of publish",          1,              staticFactoryMock.publishInvocationCount);
+
+        assertEquals("last message published, arn",     EXPECTED_ARN,   staticFactoryMock.lastPublishArn);
+        assertEquals("last message published, subject", null,           staticFactoryMock.lastPublishSubject);
+        assertEquals("last message published, body",    "message one",  staticFactoryMock.lastPublishMessage);
+    }
+}

--- a/appenders/src/test/resources/TestCloudWatchAppender/testMultipleDescribeCalls.properties
+++ b/appenders/src/test/resources/TestCloudWatchAppender/testMultipleDescribeCalls.properties
@@ -1,0 +1,11 @@
+# config for mock-object tests of writer operation; note short batch delay
+
+log4j.rootLogger=DEBUG, default
+
+log4j.appender.default=com.kdgregory.log4j.testhelpers.aws.cloudwatch.TestableCloudWatchAppender
+log4j.appender.default.layout=org.apache.log4j.PatternLayout
+log4j.appender.default.layout.ConversionPattern=%m%n
+
+log4j.appender.default.logGroup=argle
+log4j.appender.default.logStream=fribble
+log4j.appender.default.batchDelay=10

--- a/appenders/src/test/resources/TestCloudWatchAppender/testStaticClientFactory.properties
+++ b/appenders/src/test/resources/TestCloudWatchAppender/testStaticClientFactory.properties
@@ -1,4 +1,4 @@
-# config for mock-object tests of writer operation; note short batch delay
+# config for client factory test
 
 log4j.rootLogger=DEBUG, default
 
@@ -8,4 +8,4 @@ log4j.appender.default.layout=org.apache.log4j.PatternLayout
 log4j.appender.default.logGroup=argle
 log4j.appender.default.logStream=bargle
 
-log4j.appender.default.clientFactory=com.kdgregory.log4j.aws.TestCloudWatchAppender.createMockClient
+log4j.appender.default.clientFactory=com.kdgregory.log4j.aws.TestCloudWatchLogWriter.createMockClient

--- a/appenders/src/test/resources/TestKinesisAppender/testStaticClientFactory.properties
+++ b/appenders/src/test/resources/TestKinesisAppender/testStaticClientFactory.properties
@@ -1,14 +1,11 @@
-# config for mock-object testing; note low batch size and delay
+# config for client factory test
 
 log4j.rootLogger=DEBUG, default
 
 log4j.appender.default=com.kdgregory.log4j.testhelpers.aws.kinesis.TestableKinesisAppender
 log4j.appender.default.layout=org.apache.log4j.PatternLayout
-log4j.appender.default.layout.ConversionPattern=%m%n
 
 log4j.appender.default.streamName=argle
 log4j.appender.default.partitionKey=bargle
-log4j.appender.default.batchSize=20
-log4j.appender.default.batchDelay=100
 
-log4j.appender.default.clientFactory=com.kdgregory.log4j.aws.TestKinesisAppender.createMockClient
+log4j.appender.default.clientFactory=com.kdgregory.log4j.aws.TestKinesisLogWriter.createMockClient

--- a/appenders/src/test/resources/TestSNSAppender/testStaticClientFactory.properties
+++ b/appenders/src/test/resources/TestSNSAppender/testStaticClientFactory.properties
@@ -1,4 +1,4 @@
-# configuration for mock-writer test
+# configuration for client factory test
 
 log4j.rootLogger=DEBUG, default
 
@@ -8,4 +8,4 @@ log4j.appender.default.layout.ConversionPattern=%m
 
 log4j.appender.default.topicName=example
 
-log4j.appender.default.clientFactory=com.kdgregory.log4j.aws.TestSNSAppender.createMockClient
+log4j.appender.default.clientFactory=com.kdgregory.log4j.aws.TestSNSLogWriter.createMockClient


### PR DESCRIPTION
The appender unit tests were getting too large, so I broke them into tests that exercise the appender with a mock writer, and tests that exercise the writer with a mock client.

At the same time I cleaned up `MockCloudWatchClient`, allowing it to take a configurable number of loggroup/logstream names, and batch them up however the test wants. The original implementation, which always did two batches, made for very painful invocation asserts, especially in the case where a particular batch might return early.