### PR TITLE
CloudWatch dedicated writer (fixes #89)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 # Change History
 
+## 2.2.2 (2019-10-20)
+
+* CloudWatch appender now provides `dedicatedWriter` configuration parameter,
+  which tells the writer that it doesn't need to retain the latest sequence
+  number for each writes, reducing the likelihood of throttling.
+  ([#89](https://github.com/kdgregory/log4j-aws-appenders/issues/89))
+
 ## 2.2.1 (2019-05-05)
 
 * CloudWatch appender allows setting retention period when creating log group.

--- a/aws-shared/pom.xml
+++ b/aws-shared/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.kdgregory.logging</groupId>
         <artifactId>parent</artifactId>
-        <version>2.2.1</version>
+        <version>2.2.2-SNAPSHOT</version>
         <relativePath>../parent</relativePath>
     </parent>
     <artifactId>aws-shared</artifactId>

--- a/aws-shared/pom.xml
+++ b/aws-shared/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.kdgregory.logging</groupId>
         <artifactId>parent</artifactId>
-        <version>2.2.2-SNAPSHOT</version>
+        <version>2.2.2</version>
         <relativePath>../parent</relativePath>
     </parent>
     <artifactId>aws-shared</artifactId>

--- a/aws-shared/src/main/java/com/kdgregory/logging/aws/cloudwatch/CloudWatchLogWriter.java
+++ b/aws-shared/src/main/java/com/kdgregory/logging/aws/cloudwatch/CloudWatchLogWriter.java
@@ -308,7 +308,7 @@ extends AbstractLogWriter<CloudWatchWriterConfig,CloudWatchWriterStatistics,AWSL
         }
         catch (Exception ex)
         {
-            logger.error("failed to set retention policy on log group " + config.logGroupName, ex);
+            reportError("failed to set retention policy on log group " + config.logGroupName, ex);
         }
     }
 
@@ -319,16 +319,24 @@ extends AbstractLogWriter<CloudWatchWriterConfig,CloudWatchWriterStatistics,AWSL
                                             .withLogGroupName(config.logGroupName)
                                             .withLogStreamNamePrefix(config.logStreamName);
         DescribeLogStreamsResult result;
-        do
+        try
         {
-            result = describeStreamsWithRetry(request);
-            for (LogStream stream : result.getLogStreams())
+            do
             {
-                if (stream.getLogStreamName().equals(config.logStreamName))
-                    return stream;
-            }
-            request.setNextToken(result.getNextToken());
-        } while (result.getNextToken() != null);
+                result = describeStreamsWithRetry(request);
+                for (LogStream stream : result.getLogStreams())
+                {
+                    if (stream.getLogStreamName().equals(config.logStreamName))
+                        return stream;
+                }
+                request.setNextToken(result.getNextToken());
+            } while (result.getNextToken() != null);
+        }
+        catch (Exception ex)
+        {
+            reportError("unable to describe log stream", ex);
+        }
+        
         return null;
     }
 

--- a/aws-shared/src/main/java/com/kdgregory/logging/aws/cloudwatch/CloudWatchLogWriter.java
+++ b/aws-shared/src/main/java/com/kdgregory/logging/aws/cloudwatch/CloudWatchLogWriter.java
@@ -167,6 +167,8 @@ extends AbstractLogWriter<CloudWatchWriterConfig,CloudWatchWriterStatistics,AWSL
             }
             catch (InvalidSequenceTokenException ex)
             {
+                // force the token to be fetched next time through
+                sequenceToken = null;
                 stats.updateWriterRaceRetries();
                 Utils.sleepQuietly(100);
                 // continue retry loop

--- a/aws-shared/src/main/java/com/kdgregory/logging/aws/cloudwatch/CloudWatchWriterConfig.java
+++ b/aws-shared/src/main/java/com/kdgregory/logging/aws/cloudwatch/CloudWatchWriterConfig.java
@@ -26,12 +26,14 @@ extends AbstractWriterConfig
     public String logGroupName;
     public String logStreamName;
     public Integer retentionPeriod;
+    public boolean dedicatedWriter;
 
 
     /**
      *  @param actualLogGroup       Name of the log group, with all substitutions applied.
      *  @param actualLogStream      Name of the log stream, with all substitutions applied.
      *  @param retentionPeriod      A non-default retention period to use when creating log group.
+     *  @param dedicatedWriter      Indicates whether the stream will only be written by this writer.
      *  @param batchDelay           Number of milliseconds to wait after receiving first
      *                              message in batch.
      *  @param discardThreshold     Maximum number of messages to retain if unable to send.
@@ -41,7 +43,7 @@ extends AbstractWriterConfig
      *  @param clientEndpoint       Optional: explicit endpoint for client (only used with constructors).
      */
     public CloudWatchWriterConfig(
-        String actualLogGroup, String actualLogStream, Integer retentionPeriod,
+        String actualLogGroup, String actualLogStream, Integer retentionPeriod, boolean dedicatedWriter,
         long batchDelay, int discardThreshold, DiscardAction discardAction,
         String clientFactoryMethod, String clientRegion, String clientEndpoint)
     {
@@ -50,5 +52,6 @@ extends AbstractWriterConfig
         this.logGroupName = actualLogGroup;
         this.logStreamName = actualLogStream;
         this.retentionPeriod = retentionPeriod;
+        this.dedicatedWriter = dedicatedWriter;
     }
 }

--- a/aws-shared/src/main/java/com/kdgregory/logging/common/factories/DefaultThreadFactory.java
+++ b/aws-shared/src/main/java/com/kdgregory/logging/common/factories/DefaultThreadFactory.java
@@ -38,11 +38,7 @@ public class DefaultThreadFactory implements ThreadFactory
     @Override
     public void startLoggingThread(final LogWriter writer, boolean useShutdownHook, UncaughtExceptionHandler exceptionHandler)
     {
-        final Thread writerThread = new Thread(writer);
-        writerThread.setName("com-kdgregory-aws-logwriter-" + appenderName + "-" + threadNumber.getAndIncrement());
-        writerThread.setPriority(Thread.NORM_PRIORITY);
-        writerThread.setDaemon(true);
-        writerThread.setUncaughtExceptionHandler(exceptionHandler);
+        final Thread writerThread = createThread(writer, exceptionHandler);
 
         if (useShutdownHook)
         {
@@ -68,5 +64,20 @@ public class DefaultThreadFactory implements ThreadFactory
         }
 
         writerThread.start();
+    }
+
+
+    /**
+     *  Creates and initializes the thread. This can be overridden by tests that need
+     *  to work with the thread; in normal operation we just let it do its thing.
+     */
+    protected Thread createThread(LogWriter writer, UncaughtExceptionHandler exceptionHandler)
+    {
+        Thread writerThread = new Thread(writer);
+        writerThread.setName("com-kdgregory-aws-logwriter-" + appenderName + "-" + threadNumber.getAndIncrement());
+        writerThread.setPriority(Thread.NORM_PRIORITY);
+        writerThread.setDaemon(true);
+        writerThread.setUncaughtExceptionHandler(exceptionHandler);
+        return writerThread;
     }
 }

--- a/aws-shared/src/test/java/com/kdgregory/logging/aws/TestCloudWatchLogWriter.java
+++ b/aws-shared/src/test/java/com/kdgregory/logging/aws/TestCloudWatchLogWriter.java
@@ -89,6 +89,7 @@ extends AbstractLogWriterTest<CloudWatchLogWriter,CloudWatchWriterConfig,CloudWa
             "argle",                // log group name
             "bargle",               // log stream name
             null,                   // retention period
+            false,                  // dedicated stream
             100,                    // batch delay -- short enough to keep tests fast, long enough that we can write a lot of messages
             10000,                  // discard threshold
             DiscardAction.oldest,   // discard action
@@ -117,11 +118,12 @@ extends AbstractLogWriterTest<CloudWatchLogWriter,CloudWatchWriterConfig,CloudWa
     @Test
     public void testConfiguration() throws Exception
     {
-        config = new CloudWatchWriterConfig("foo", "bar", 1, 123, 456, DiscardAction.newest, "com.example.factory.Method", "us-west-1", "logs.us-west-1.amazonaws.com");
+        config = new CloudWatchWriterConfig("foo", "bar", 1, true, 123, 456, DiscardAction.newest, "com.example.factory.Method", "us-west-1", "logs.us-west-1.amazonaws.com");
 
         assertEquals("log group name",                          "foo",                  config.logGroupName);
         assertEquals("log stream name",                         "bar",                  config.logStreamName);
         assertEquals("retention period",                        Integer.valueOf(1),     config.retentionPeriod);
+        assertEquals("dedicated stream",                        true,                   config.dedicatedStream);
 
         writer = new CloudWatchLogWriter(config, stats, internalLogger, dummyClientFactory);
         messageQueue = ClassUtil.getFieldValue(writer, "messageQueue", MessageQueue.class);

--- a/aws-shared/src/test/java/com/kdgregory/logging/testhelpers/TestableInternalLogger.java
+++ b/aws-shared/src/test/java/com/kdgregory/logging/testhelpers/TestableInternalLogger.java
@@ -27,7 +27,7 @@ import com.kdgregory.logging.common.util.InternalLogger;
 
 /**
  *  An implementation of <code>InternalLogger</code> that retains messages for
- *  analysis by test code.
+ *  analysis by test code. Thread-safe for adding messages, but not for reading.
  */
 public class TestableInternalLogger
 implements InternalLogger
@@ -39,7 +39,7 @@ implements InternalLogger
 
 
     @Override
-    public void debug(String message)
+    public synchronized void debug(String message)
     {
         debugMessages.add(message);
     }
@@ -47,7 +47,7 @@ implements InternalLogger
 
 
     @Override
-    public void warn(String message)
+    public synchronized void warn(String message)
     {
         warnMessages.add(message);
     }
@@ -55,7 +55,7 @@ implements InternalLogger
 
 
     @Override
-    public void error(String message, Throwable ex)
+    public synchronized void error(String message, Throwable ex)
     {
         errorMessages.add(message);
         errorExceptions.add(ex);

--- a/aws-shared/src/test/java/com/kdgregory/logging/testhelpers/cloudwatch/MockCloudWatchClient.java
+++ b/aws-shared/src/test/java/com/kdgregory/logging/testhelpers/cloudwatch/MockCloudWatchClient.java
@@ -77,7 +77,7 @@ implements InvocationHandler
 
     // the sequence token used for putLogEvents(); start with arbitrary value to
     // verify that we're actually retrieving it from describe
-    protected int putLogEventsSequenceToken = (int)(System.currentTimeMillis() % 143);
+    public int putLogEventsSequenceToken = (int)(System.currentTimeMillis() % 143);
 
     // these semaphores coordinate the calls to PutLogEvents with the assertions
     // that we make in the main thread; note that both start unacquired

--- a/examples/log4j1-example/pom.xml
+++ b/examples/log4j1-example/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.kdgregory.logging</groupId>
     <artifactId>log4j1-aws-appenders-example</artifactId>
-    <version>2.2.1</version>
+    <version>2.2.2-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Log4J 1.x Example</name>

--- a/examples/log4j1-example/pom.xml
+++ b/examples/log4j1-example/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.kdgregory.logging</groupId>
     <artifactId>log4j1-aws-appenders-example</artifactId>
-    <version>2.2.2-SNAPSHOT</version>
+    <version>2.2.2</version>
     <packaging>jar</packaging>
 
     <name>Log4J 1.x Example</name>

--- a/examples/log4j1-example/src/main/resources/log4j.properties
+++ b/examples/log4j1-example/src/main/resources/log4j.properties
@@ -14,6 +14,7 @@ log4j.appender.console.layout.ConversionPattern=%d{ISO8601} %-5p [%t] %c - %m%n
 log4j.appender.cloudwatch=com.kdgregory.log4j.aws.CloudWatchAppender
 log4j.appender.cloudwatch.logGroup=AppenderExample
 log4j.appender.cloudwatch.logStream=Example-{date}-{hostname}-{pid}
+log4j.appender.cloudwatch.dedicatedWriter=true
 log4j.appender.cloudwatch.layout=org.apache.log4j.PatternLayout
 log4j.appender.cloudwatch.layout.ConversionPattern=%d{ISO8601} %-5p [%t] %c - %m%n
 

--- a/examples/log4j1-webapp/pom.xml
+++ b/examples/log4j1-webapp/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.kdgregory.logging</groupId>
     <artifactId>log4j1-aws-appenders-webapp</artifactId>
-    <version>2.2.1</version>
+    <version>2.2.2-SNAPSHOT</version>
     <packaging>war</packaging>
 
     <name>Log4J 1.x Webapp Example</name>

--- a/examples/log4j1-webapp/pom.xml
+++ b/examples/log4j1-webapp/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.kdgregory.logging</groupId>
     <artifactId>log4j1-aws-appenders-webapp</artifactId>
-    <version>2.2.2-SNAPSHOT</version>
+    <version>2.2.2</version>
     <packaging>war</packaging>
 
     <name>Log4J 1.x Webapp Example</name>

--- a/examples/log4j1-webapp/src/main/resources/log4j.properties
+++ b/examples/log4j1-webapp/src/main/resources/log4j.properties
@@ -9,6 +9,7 @@ log4j.appender.console.layout.ConversionPattern=%d{ISO8601} %-5p [%t] %c - %m%n
 log4j.appender.cloudwatch=com.kdgregory.log4j.aws.CloudWatchAppender
 log4j.appender.cloudwatch.logGroup=AppenderExample
 log4j.appender.cloudwatch.logStream=WebApp-{date}-{hostname}-{pid}
+log4j.appender.cloudwatch.dedicatedWriter=true
 log4j.appender.cloudwatch.layout=org.apache.log4j.PatternLayout
 log4j.appender.cloudwatch.layout.ConversionPattern=%d{ISO8601} %-5p [%t] %c - %m%n
 

--- a/examples/logback-example/pom.xml
+++ b/examples/logback-example/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.kdgregory.logging</groupId>
     <artifactId>logback-aws-appenders-example</artifactId>
-    <version>2.2.1</version>
+    <version>2.2.2-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Logback Example</name>

--- a/examples/logback-example/pom.xml
+++ b/examples/logback-example/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.kdgregory.logging</groupId>
     <artifactId>logback-aws-appenders-example</artifactId>
-    <version>2.2.2-SNAPSHOT</version>
+    <version>2.2.2</version>
     <packaging>jar</packaging>
 
     <name>Logback Example</name>

--- a/examples/logback-example/src/main/resources/logback.xml
+++ b/examples/logback-example/src/main/resources/logback.xml
@@ -13,6 +13,7 @@
     <appender name="CLOUDWATCH" class="com.kdgregory.logback.aws.CloudWatchAppender">
         <logGroup>AppenderExample</logGroup>
         <logStream>Example-{date}-{hostname}-{pid}</logStream>
+        <dedicatedWriter>true</dedicatedWriter>
         <layout class="ch.qos.logback.classic.PatternLayout">
             <pattern>%d{ISO8601} %-5level [%thread] %logger{24} - %msg%n</pattern>
         </layout>

--- a/examples/logback-webapp/pom.xml
+++ b/examples/logback-webapp/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.kdgregory.logging</groupId>
     <artifactId>logback-aws-appenders-webapp</artifactId>
-    <version>2.2.1</version>
+    <version>2.2.2-SNAPSHOT</version>
     <packaging>war</packaging>
 
     <name>Logback Webapp Example</name>

--- a/examples/logback-webapp/pom.xml
+++ b/examples/logback-webapp/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.kdgregory.logging</groupId>
     <artifactId>logback-aws-appenders-webapp</artifactId>
-    <version>2.2.2-SNAPSHOT</version>
+    <version>2.2.2</version>
     <packaging>war</packaging>
 
     <name>Logback Webapp Example</name>

--- a/examples/logback-webapp/src/main/resources/logback.xml
+++ b/examples/logback-webapp/src/main/resources/logback.xml
@@ -11,6 +11,7 @@
     <appender name="CLOUDWATCH" class="com.kdgregory.logback.aws.CloudWatchAppender">
         <logGroup>AppenderExample</logGroup>
         <logStream>WebApp-{date}-{hostname}-{pid}</logStream>
+        <dedicatedWriter>true</dedicatedWriter>
         <layout class="ch.qos.logback.classic.PatternLayout">
             <pattern>%d{ISO8601} %-5level [%thread] %logger{24} - %msg%n</pattern>
         </layout>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.kdgregory.logging</groupId>
     <artifactId>examples</artifactId>
-    <version>2.2.1</version>
+    <version>2.2.2-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>AWS Log Appenders - Examples</name>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.kdgregory.logging</groupId>
     <artifactId>examples</artifactId>
-    <version>2.2.2-SNAPSHOT</version>
+    <version>2.2.2</version>
     <packaging>pom</packaging>
 
     <name>AWS Log Appenders - Examples</name>

--- a/integration-tests/aws-testhelpers/pom.xml
+++ b/integration-tests/aws-testhelpers/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.kdgregory.logging</groupId>
         <artifactId>parent</artifactId>
-        <version>2.2.1</version>
+        <version>2.2.2-SNAPSHOT</version>
         <relativePath>../../parent</relativePath>
     </parent>
     <artifactId>aws-testhelpers</artifactId>

--- a/integration-tests/aws-testhelpers/pom.xml
+++ b/integration-tests/aws-testhelpers/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.kdgregory.logging</groupId>
         <artifactId>parent</artifactId>
-        <version>2.2.2-SNAPSHOT</version>
+        <version>2.2.2</version>
         <relativePath>../../parent</relativePath>
     </parent>
     <artifactId>aws-testhelpers</artifactId>

--- a/integration-tests/cloudwatch-logwriter-integration-tests/pom.xml
+++ b/integration-tests/cloudwatch-logwriter-integration-tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.kdgregory.logging</groupId>
         <artifactId>parent</artifactId>
-        <version>2.2.1</version>
+        <version>2.2.2-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <artifactId>cloudwatch-logwriter-integration-tests</artifactId>

--- a/integration-tests/cloudwatch-logwriter-integration-tests/pom.xml
+++ b/integration-tests/cloudwatch-logwriter-integration-tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.kdgregory.logging</groupId>
         <artifactId>parent</artifactId>
-        <version>2.2.2-SNAPSHOT</version>
+        <version>2.2.2</version>
         <relativePath/>
     </parent>
     <artifactId>cloudwatch-logwriter-integration-tests</artifactId>

--- a/integration-tests/kinesis-logwriter-integration-tests/pom.xml
+++ b/integration-tests/kinesis-logwriter-integration-tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.kdgregory.logging</groupId>
         <artifactId>parent</artifactId>
-        <version>2.2.1</version>
+        <version>2.2.2-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <artifactId>kinesis-logwriter-integration-tests</artifactId>

--- a/integration-tests/kinesis-logwriter-integration-tests/pom.xml
+++ b/integration-tests/kinesis-logwriter-integration-tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.kdgregory.logging</groupId>
         <artifactId>parent</artifactId>
-        <version>2.2.2-SNAPSHOT</version>
+        <version>2.2.2</version>
         <relativePath/>
     </parent>
     <artifactId>kinesis-logwriter-integration-tests</artifactId>

--- a/integration-tests/log4j1-integration-tests/pom.xml
+++ b/integration-tests/log4j1-integration-tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.kdgregory.logging</groupId>
         <artifactId>parent</artifactId>
-        <version>2.2.1</version>
+        <version>2.2.2-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <artifactId>log4j1-aws-appenders-test</artifactId>

--- a/integration-tests/log4j1-integration-tests/pom.xml
+++ b/integration-tests/log4j1-integration-tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.kdgregory.logging</groupId>
         <artifactId>parent</artifactId>
-        <version>2.2.2-SNAPSHOT</version>
+        <version>2.2.2</version>
         <relativePath/>
     </parent>
     <artifactId>log4j1-aws-appenders-test</artifactId>

--- a/integration-tests/logback-integration-tests/pom.xml
+++ b/integration-tests/logback-integration-tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.kdgregory.logging</groupId>
         <artifactId>parent</artifactId>
-        <version>2.2.1</version>
+        <version>2.2.2-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <artifactId>logback-aws-appenders-test</artifactId>

--- a/integration-tests/logback-integration-tests/pom.xml
+++ b/integration-tests/logback-integration-tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.kdgregory.logging</groupId>
         <artifactId>parent</artifactId>
-        <version>2.2.2-SNAPSHOT</version>
+        <version>2.2.2</version>
         <relativePath/>
     </parent>
     <artifactId>logback-aws-appenders-test</artifactId>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.kdgregory.logging</groupId>
     <artifactId>integration-tests</artifactId>
-    <version>2.2.1</version>
+    <version>2.2.2-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>AWS Log Appenders - Integration Tests</name>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.kdgregory.logging</groupId>
     <artifactId>integration-tests</artifactId>
-    <version>2.2.2-SNAPSHOT</version>
+    <version>2.2.2</version>
     <packaging>pom</packaging>
 
     <name>AWS Log Appenders - Integration Tests</name>

--- a/integration-tests/sns-logwriter-integration-tests/pom.xml
+++ b/integration-tests/sns-logwriter-integration-tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.kdgregory.logging</groupId>
         <artifactId>parent</artifactId>
-        <version>2.2.1</version>
+        <version>2.2.2-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <artifactId>sns-logwriter-integration-tests</artifactId>

--- a/integration-tests/sns-logwriter-integration-tests/pom.xml
+++ b/integration-tests/sns-logwriter-integration-tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.kdgregory.logging</groupId>
         <artifactId>parent</artifactId>
-        <version>2.2.2-SNAPSHOT</version>
+        <version>2.2.2</version>
         <relativePath/>
     </parent>
     <artifactId>sns-logwriter-integration-tests</artifactId>

--- a/log4j1-appenders/pom.xml
+++ b/log4j1-appenders/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.kdgregory.logging</groupId>
         <artifactId>parent</artifactId>
-        <version>2.2.1</version>
+        <version>2.2.2-SNAPSHOT</version>
         <relativePath>../parent</relativePath>
     </parent>
     <artifactId>log4j1-aws-appenders</artifactId>

--- a/log4j1-appenders/pom.xml
+++ b/log4j1-appenders/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.kdgregory.logging</groupId>
         <artifactId>parent</artifactId>
-        <version>2.2.2-SNAPSHOT</version>
+        <version>2.2.2</version>
         <relativePath>../parent</relativePath>
     </parent>
     <artifactId>log4j1-aws-appenders</artifactId>

--- a/log4j1-appenders/src/main/java/com/kdgregory/log4j/aws/CloudWatchAppender.java
+++ b/log4j1-appenders/src/main/java/com/kdgregory/log4j/aws/CloudWatchAppender.java
@@ -34,6 +34,7 @@ extends AbstractAppender<CloudWatchWriterConfig,CloudWatchWriterStatistics,Cloud
     private String  logGroup;
     private String  logStream;
     private Integer retentionPeriod;
+    private boolean dedicatedWriter;
 
 
     /**
@@ -148,6 +149,27 @@ extends AbstractAppender<CloudWatchWriterConfig,CloudWatchWriterStatistics,Cloud
         return (retentionPeriod == null) ? 0 : retentionPeriod.intValue();
     }
 
+
+    /**
+     *  Sets a flag indicating that this appender will be the only writer to
+     *  the stream. This allows the appender to cache the sequence token from
+     *  each write, rather than requesting the current token (which will be
+     *  throttled with large numbers of writers).
+     */
+    public void setDedicatedWriter(boolean value)
+    {
+        dedicatedWriter = value;
+    }
+
+
+    /**
+     *  Returns the flag indicating whether appender is a dedicated writer.
+     */
+    public boolean getDedicatedWriter()
+    {
+        return dedicatedWriter;
+    }
+
 //----------------------------------------------------------------------------
 //  AbstractAppender overrides
 //----------------------------------------------------------------------------
@@ -176,7 +198,7 @@ extends AbstractAppender<CloudWatchWriterConfig,CloudWatchWriterStatistics,Cloud
         String actualLogStream  = subs.perform(logStream);
 
         return new CloudWatchWriterConfig(
-            actualLogGroup, actualLogStream, retentionPeriod,
+            actualLogGroup, actualLogStream, retentionPeriod, dedicatedWriter,
             batchDelay, discardThreshold, discardAction,
             clientFactory, clientRegion, clientEndpoint);
     }

--- a/log4j1-appenders/src/test/java/com/kdgregory/log4j/aws/TestCloudWatchAppender.java
+++ b/log4j1-appenders/src/test/java/com/kdgregory/log4j/aws/TestCloudWatchAppender.java
@@ -87,6 +87,7 @@ public class TestCloudWatchAppender
         assertEquals("log group name",      "argle",                        appender.getLogGroup());
         assertEquals("log stream name",     "bargle",                       appender.getLogStream());
         assertEquals("retention period",    7,                              appender.getRetentionPeriod());
+        assertTrue("dedicated writer",                                      appender.getDedicatedWriter());
         assertEquals("batch delay",         9876L,                          appender.getBatchDelay());
         assertEquals("sequence",            2,                              appender.getSequence());
         assertEquals("rotation mode",       "interval",                     appender.getRotationMode());
@@ -111,6 +112,7 @@ public class TestCloudWatchAppender
 
         assertEquals("log stream name",     "{startupTimestamp}",           appender.getLogStream());
         assertEquals("retention period",    0,                              appender.getRetentionPeriod());
+        assertFalse("dedicated writer",                                     appender.getDedicatedWriter());
         assertEquals("batch delay",         2000L,                          appender.getBatchDelay());
         assertEquals("sequence",            0,                              appender.getSequence());
         assertEquals("rotation mode",       "none",                         appender.getRotationMode());

--- a/log4j1-appenders/src/test/resources/TestCloudWatchAppender/testConfiguration.properties
+++ b/log4j1-appenders/src/test/resources/TestCloudWatchAppender/testConfiguration.properties
@@ -9,6 +9,7 @@ log4j.appender.default.layout.ConversionPattern=%m
 log4j.appender.default.logGroup=argle
 log4j.appender.default.logStream=bargle
 log4j.appender.default.retentionPeriod=7
+log4j.appender.default.dedicatedWriter=true
 log4j.appender.default.batchDelay=9876
 log4j.appender.default.sequence=2
 log4j.appender.default.rotationMode=interval

--- a/logback-appenders/pom.xml
+++ b/logback-appenders/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.kdgregory.logging</groupId>
         <artifactId>parent</artifactId>
-        <version>2.2.1</version>
+        <version>2.2.2-SNAPSHOT</version>
         <relativePath>../parent</relativePath>
     </parent>
     <artifactId>logback-aws-appenders</artifactId>

--- a/logback-appenders/pom.xml
+++ b/logback-appenders/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.kdgregory.logging</groupId>
         <artifactId>parent</artifactId>
-        <version>2.2.2-SNAPSHOT</version>
+        <version>2.2.2</version>
         <relativePath>../parent</relativePath>
     </parent>
     <artifactId>logback-aws-appenders</artifactId>

--- a/logback-appenders/src/main/java/com/kdgregory/logback/aws/CloudWatchAppender.java
+++ b/logback-appenders/src/main/java/com/kdgregory/logback/aws/CloudWatchAppender.java
@@ -34,6 +34,7 @@ extends AbstractAppender<CloudWatchWriterConfig,CloudWatchWriterStatistics,Cloud
     private String  logGroup;
     private String  logStream;
     private Integer retentionPeriod;
+    private boolean dedicatedWriter;
 
 
     public CloudWatchAppender()
@@ -143,6 +144,27 @@ extends AbstractAppender<CloudWatchWriterConfig,CloudWatchWriterStatistics,Cloud
         return retentionPeriod;
     }
 
+
+    /**
+     *  Sets a flag indicating that this appender will be the only writer to
+     *  the stream. This allows the appender to cache the sequence token from
+     *  each write, rather than requesting the current token (which will be
+     *  throttled with large numbers of writers).
+     */
+    public void setDedicatedWriter(boolean value)
+    {
+        dedicatedWriter = value;
+    }
+
+
+    /**
+     *  Returns the flag indicating whether appender is a dedicated writer.
+     */
+    public boolean getDedicatedWriter()
+    {
+        return dedicatedWriter;
+    }
+
 //----------------------------------------------------------------------------
 //  AbstractAppender overrides
 //----------------------------------------------------------------------------
@@ -171,7 +193,7 @@ extends AbstractAppender<CloudWatchWriterConfig,CloudWatchWriterStatistics,Cloud
         String actualLogStream = subs.perform(logStream);
 
         return new CloudWatchWriterConfig(
-            actualLogGroup, actualLogStream, retentionPeriod,
+            actualLogGroup, actualLogStream, retentionPeriod, dedicatedWriter,
             batchDelay, discardThreshold, discardAction,
             clientFactory, clientRegion, clientEndpoint);
     }

--- a/logback-appenders/src/test/java/com/kdgregory/logback/aws/TestCloudWatchAppender.java
+++ b/logback-appenders/src/test/java/com/kdgregory/logback/aws/TestCloudWatchAppender.java
@@ -71,6 +71,7 @@ public class TestCloudWatchAppender
         assertEquals("log group name",      "argle",                        appender.getLogGroup());
         assertEquals("log stream name",     "bargle",                       appender.getLogStream());
         assertEquals("retention period",    Integer.valueOf(7),             appender.getRetentionPeriod());
+        assertTrue("dedicated writer",                                      appender.getDedicatedWriter());
         assertEquals("batch delay",         9876L,                          appender.getBatchDelay());
         assertEquals("sequence",            2,                              appender.getSequence());
         assertEquals("rotation mode",       "interval",                     appender.getRotationMode());
@@ -95,6 +96,7 @@ public class TestCloudWatchAppender
 
         assertEquals("log stream name",     "{startupTimestamp}",           appender.getLogStream());
         assertEquals("retention period",    null,                           appender.getRetentionPeriod());
+        assertFalse("dedicated writer",                                     appender.getDedicatedWriter());
         assertEquals("batch delay",         2000L,                          appender.getBatchDelay());
         assertEquals("sequence",            0,                              appender.getSequence());
         assertEquals("rotation mode",       "none",                         appender.getRotationMode());

--- a/logback-appenders/src/test/resources/TestCloudWatchAppender/testConfiguration.xml
+++ b/logback-appenders/src/test/resources/TestCloudWatchAppender/testConfiguration.xml
@@ -6,6 +6,7 @@
     <logGroup>argle</logGroup>
     <logStream>bargle</logStream>
     <retentionPeriod>7</retentionPeriod>
+    <dedicatedWriter>true</dedicatedWriter>
     <synchronous>false</synchronous> <!-- explicitly set to default value -->
     <batchDelay>9876</batchDelay>
     <sequence>2</sequence>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.kdgregory.logging</groupId>
     <artifactId>parent</artifactId>
-    <version>2.2.1</version>
+    <version>2.2.2-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Parent POM</name>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.kdgregory.logging</groupId>
     <artifactId>parent</artifactId>
-    <version>2.2.2-SNAPSHOT</version>
+    <version>2.2.2</version>
     <packaging>pom</packaging>
 
     <name>Parent POM</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.kdgregory.logging</groupId>
     <artifactId>root</artifactId>
-    <version>2.2.1</version>
+    <version>2.2.2-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>AWS Log Appenders Root Build</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.kdgregory.logging</groupId>
     <artifactId>root</artifactId>
-    <version>2.2.2-SNAPSHOT</version>
+    <version>2.2.2</version>
     <packaging>pom</packaging>
 
     <name>AWS Log Appenders Root Build</name>


### PR DESCRIPTION
The process of retrieving the sequence token for each write falls down in high-concurrency deployments, because it's limited to 5 requests per second. This PR adds a configuration parameter that will tell the log writer to assume that it's the only thing writing to a logstream, so it will hold onto the returned sequence token. Will fallback to retrieving if needed.

This is non-default behavior for backwards compatibility.