### PR TITLE
support EC2 tags in substitutions (fixes #36)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@
 
 * Support AWS SDK v2.
   ([#118](https://github.com/kdgregory/log4j-aws-appenders/issues/118))
+* Can now use an `{ec2:tag}` substitution when running on EC2.
+  ([#36](https://github.com/kdgregory/log4j-aws-appenders/issues/36))
 * Can now use a `{uuid}` substitution.
   ([#128](https://github.com/kdgregory/log4j-aws-appenders/issues/128))
 * Now supports client endpoint configuration in all cases.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@
 
 * Support AWS SDK v2.
   ([#118](https://github.com/kdgregory/log4j-aws-appenders/issues/118))
-* Can now use an `{ec2:tag}` substitution when running on EC2.
+* Can now use an `{ec2:tag:XXX}` substitution when running on EC2.
   ([#36](https://github.com/kdgregory/log4j-aws-appenders/issues/36))
 * Can now use a `{uuid}` substitution.
   ([#128](https://github.com/kdgregory/log4j-aws-appenders/issues/128))

--- a/docs/build.md
+++ b/docs/build.md
@@ -125,6 +125,20 @@ permissions that are not needed for normal use of an appender.
     "Version": "2012-10-17",
     "Statement": [
         {
+            "Sid": "AssumedRole",
+            "Effect": "Allow",
+            "Action": [
+                "iam:CreateRole",
+                "iam:DeleteRole",
+                "iam:ListAttachedRolePolicies",
+                "iam:AttachRolePolicy",
+                "iam:DetachRolePolicy",
+                "iam:ListRoles",
+                "sts:AssumeRole"
+            ],
+            "Resource": "*"
+        },
+        {
             "Sid": "CloudWatchLogs",
             "Effect": "Allow",
             "Action": [
@@ -137,6 +151,15 @@ permissions that are not needed for normal use of an appender.
                 "logs:GetLogEvents",
                 "logs:PutLogEvents",
                 "logs:PutRetentionPolicy"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Sid": "EC2Tags",
+            "Effect": "Allow",
+            "Action": [
+                "ec2:CreateTags",
+                "ec2:DescribeTags"
             ],
             "Resource": "*"
         },
@@ -188,20 +211,6 @@ permissions that are not needed for normal use of an appender.
                 "ssm:DeleteParameter",
                 "ssm:GetParameter",
                 "ssm:PutParameter"
-            ],
-            "Resource": "*"
-        },
-        {
-            "Sid": "AssumedRole",
-            "Effect": "Allow",
-            "Action": [
-                "iam:CreateRole",
-                "iam:DeleteRole",
-                "iam:ListAttachedRolePolicies",
-                "iam:AttachRolePolicy",
-                "iam:DetachRolePolicy",
-                "iam:ListRoles",
-                "sts:AssumeRole"
             ],
             "Resource": "*"
         }

--- a/docs/substitutions.md
+++ b/docs/substitutions.md
@@ -20,6 +20,7 @@ Variable            | Description
 `aws:accountId`     | AWS account ID. Useful for cross-account logging (eg, as part of a CloudWatch log stream name)
 `ec2:instanceId`    | EC2 instance ID; see below.
 `ec2:region`        | Region where the current instance is running; see below.
+`ec2:tag:XXX`       | The EC2 instance tag named `XXX`; see below.
 `ssm:XXX`           | Parameter Store value `XXX`; see [below](#default-values) for complete syntax.
 
 
@@ -28,6 +29,9 @@ to a incorrect or unclosed tag, or an unresolvable system property or environmen
 
 Substitutions may not be nested: if you use an `env` substitution that returns the string `{date}`,
 that literal value will be the substitution result.
+
+
+## Notes
 
 The `pid` and `hostname` values are parsed from `RuntimeMxBean.getName()` and may not be available
 on all JVMs (in particular non-OpenJDK JVMs may use a different format). When running in a Docker
@@ -40,6 +44,11 @@ AWS SDK library in your classpath (see below).
 The `ec2` substitutions retrieve their information from the EC2 metadata service. Using these
 variables in any other environment will result in a (long) wait as the SDK tries to make an HTTP
 request to the (non-existent) metadata endpoint.
+
+The `ec2:tag` substution only applies when running on EC2. It retrieves the instance ID, and from
+that attempts to retrieve the named tag. If unable to retrieve the tag, returns "unknown". To use
+this substitution variable, you must include the EC2 client library and have the `ec2:DescribeTags`
+permission.
 
 The `ssm` substitutions retrieve their values from the [Systems Manager Parameter
 Store](https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-parameter-store.html).

--- a/integration-tests/appenders/abstract-appender/pom.xml
+++ b/integration-tests/appenders/abstract-appender/pom.xml
@@ -6,7 +6,7 @@
         <groupId>com.kdgregory.logging</groupId>
         <artifactId>parent</artifactId>
         <version>3.0.0-SNAPSHOT</version>
-        <relativePath/>
+        <relativePath>../../../library/parent</relativePath>
     </parent>
 
     <groupId>com.kdgregory.logging.integration-test</groupId>

--- a/integration-tests/helpers/itest-helper-v1/pom.xml
+++ b/integration-tests/helpers/itest-helper-v1/pom.xml
@@ -6,7 +6,7 @@
         <groupId>com.kdgregory.logging</groupId>
         <artifactId>parent</artifactId>
         <version>3.0.0-SNAPSHOT</version>
-        <relativePath>../../library/parent</relativePath>
+        <relativePath>../../../library/parent</relativePath>
     </parent>
 
     <groupId>com.kdgregory.logging.integration-test</groupId>

--- a/integration-tests/helpers/itest-helper-v2/pom.xml
+++ b/integration-tests/helpers/itest-helper-v2/pom.xml
@@ -6,7 +6,7 @@
         <groupId>com.kdgregory.logging</groupId>
         <artifactId>parent</artifactId>
         <version>3.0.0-SNAPSHOT</version>
-        <relativePath>../../library/parent</relativePath>
+        <relativePath>../../../library/parent</relativePath>
     </parent>
 
     <groupId>com.kdgregory.logging.integration-test</groupId>

--- a/integration-tests/logwriter-v1/logwriter-extended/pom.xml
+++ b/integration-tests/logwriter-v1/logwriter-extended/pom.xml
@@ -54,6 +54,12 @@
 
         <dependency>
             <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-ec2</artifactId>
+            <version>${aws-sdk-v1.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-iam</artifactId>
             <version>${aws-sdk-v1.version}</version>
             <scope>test</scope>

--- a/integration-tests/logwriter-v1/logwriter-extended/src/test/java/com/kdgregory/logging/aws/TestInfoFacadeEC2Environment.java
+++ b/integration-tests/logwriter-v1/logwriter-extended/src/test/java/com/kdgregory/logging/aws/TestInfoFacadeEC2Environment.java
@@ -14,10 +14,19 @@
 
 package com.kdgregory.logging.aws;
 
+import java.util.Map;
+import java.util.UUID;
+
 import org.junit.Ignore;
 import org.junit.Test;
+import static org.junit.Assert.*;
 
 import net.sf.kdgcommons.test.StringAsserts;
+
+import com.amazonaws.services.ec2.AmazonEC2;
+import com.amazonaws.services.ec2.AmazonEC2ClientBuilder;
+import com.amazonaws.services.ec2.model.CreateTagsRequest;
+import com.amazonaws.services.ec2.model.Tag;
 
 import com.kdgregory.logging.aws.facade.FacadeFactory;
 import com.kdgregory.logging.aws.facade.InfoFacade;
@@ -58,4 +67,28 @@ public class TestInfoFacadeEC2Environment
         StringAsserts.assertRegex("retrieved value (was: " + value + ")",
                                   "..-.*-\\d",
                                   value);
-    }}
+    }
+
+
+    @Test
+    @Ignore
+    public void testTags() throws Exception
+    {
+        InfoFacade facade = FacadeFactory.createFacade(InfoFacade.class);
+
+        String instanceId = facade.retrieveEC2InstanceId();
+
+        String tagName = UUID.randomUUID().toString();
+        String tagValue = UUID.randomUUID().toString();
+
+        AmazonEC2 client = AmazonEC2ClientBuilder.defaultClient();
+
+        CreateTagsRequest createRequest = new CreateTagsRequest()
+                                          .withResources(instanceId)
+                                          .withTags(new Tag(tagName, tagValue));
+        client.createTags(createRequest);
+
+        Map<String,String> retrievedTags = facade.retrieveEC2Tags(instanceId);
+        assertEquals("tag returned", tagValue, retrievedTags.get(tagName));
+    }
+}

--- a/integration-tests/logwriter-v2/logwriter-extended/pom.xml
+++ b/integration-tests/logwriter-v2/logwriter-extended/pom.xml
@@ -60,6 +60,12 @@
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
+            <artifactId>ec2</artifactId>
+            <version>${aws-sdk-v2.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
             <artifactId>iam</artifactId>
             <version>${aws-sdk-v2.version}</version>
             <scope>test</scope>

--- a/integration-tests/logwriter-v2/logwriter-extended/src/test/java/com/kdgregory/logging/aws/TestInfoFacadeEC2Environment.java
+++ b/integration-tests/logwriter-v2/logwriter-extended/src/test/java/com/kdgregory/logging/aws/TestInfoFacadeEC2Environment.java
@@ -14,13 +14,21 @@
 
 package com.kdgregory.logging.aws;
 
+import java.util.Map;
+import java.util.UUID;
+
 import org.junit.Ignore;
 import org.junit.Test;
+import static org.junit.Assert.*;
 
 import net.sf.kdgcommons.test.StringAsserts;
 
 import com.kdgregory.logging.aws.facade.FacadeFactory;
 import com.kdgregory.logging.aws.facade.InfoFacade;
+
+import software.amazon.awssdk.services.ec2.Ec2Client;
+import software.amazon.awssdk.services.ec2.model.CreateTagsRequest;
+import software.amazon.awssdk.services.ec2.model.Tag;
 
 
 /**
@@ -58,4 +66,30 @@ public class TestInfoFacadeEC2Environment
         StringAsserts.assertRegex("retrieved value (was: " + value + ")",
                                   "..-.*-\\d",
                                   value);
-    }}
+    }
+
+
+    @Test
+    @Ignore
+    public void testTags() throws Exception
+    {
+        InfoFacade facade = FacadeFactory.createFacade(InfoFacade.class);
+
+        String instanceId = facade.retrieveEC2InstanceId();
+
+        String tagName = UUID.randomUUID().toString();
+        String tagValue = UUID.randomUUID().toString();
+
+        Ec2Client client = Ec2Client.builder().build();
+
+        CreateTagsRequest createRequest = CreateTagsRequest.builder()
+                                          .resources(instanceId)
+                                          .tags(Tag.builder().key(tagName).value(tagValue).build())
+                                          .build();
+        client.createTags(createRequest);
+
+        Map<String,String> retrievedTags = facade.retrieveEC2Tags(instanceId);
+        assertEquals("tag returned", tagValue, retrievedTags.get(tagName));
+    }
+
+}

--- a/library/aws-facade-v1/pom.xml
+++ b/library/aws-facade-v1/pom.xml
@@ -24,7 +24,13 @@
             <artifactId>shared</artifactId>
             <version>${project.version}</version>
         </dependency>
-        
+
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-ec2</artifactId>
+            <version>${aws-sdk-v1.version}</version>
+            <scope>provided</scope>
+        </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-iam</artifactId>

--- a/library/aws-facade-v1/src/main/java/com/kdgregory/logging/aws/facade/v1/InfoFacadeImpl.java
+++ b/library/aws-facade-v1/src/main/java/com/kdgregory/logging/aws/facade/v1/InfoFacadeImpl.java
@@ -14,6 +14,8 @@
 
 package com.kdgregory.logging.aws.facade.v1;
 
+import java.util.Map;
+
 import com.amazonaws.regions.DefaultAwsRegionProviderChain;
 import com.amazonaws.services.securitytoken.AWSSecurityTokenService;
 import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClientBuilder;
@@ -67,6 +69,13 @@ implements InfoFacade
     public String retrieveEC2Region()
     {
         return EC2MetadataUtils.getEC2InstanceRegion();
+    }
+
+
+    @Override
+    public Map<String,String> retrieveEC2Tags(String instanceId)
+    {
+        throw new UnsupportedOperationException("FIXME - implement");
     }
 
 

--- a/library/aws-facade-v1/src/main/java/com/kdgregory/logging/aws/facade/v1/InfoFacadeImpl.java
+++ b/library/aws-facade-v1/src/main/java/com/kdgregory/logging/aws/facade/v1/InfoFacadeImpl.java
@@ -14,9 +14,15 @@
 
 package com.kdgregory.logging.aws.facade.v1;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import com.amazonaws.regions.DefaultAwsRegionProviderChain;
+import com.amazonaws.services.ec2.AmazonEC2;
+import com.amazonaws.services.ec2.AmazonEC2ClientBuilder;
+import com.amazonaws.services.ec2.model.*;
 import com.amazonaws.services.securitytoken.AWSSecurityTokenService;
 import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClientBuilder;
 import com.amazonaws.services.securitytoken.model.*;
@@ -75,7 +81,35 @@ implements InfoFacade
     @Override
     public Map<String,String> retrieveEC2Tags(String instanceId)
     {
-        throw new UnsupportedOperationException("FIXME - implement");
+        return retryManager.invoke(() -> {
+            try
+            {
+                List<Filter> filters = new ArrayList<>();
+                filters.add(new Filter().withName("resource-type").withValues("instance"));
+                filters.add(new Filter().withName("resource-id").withValues(instanceId));
+
+                DescribeTagsRequest request = new DescribeTagsRequest().withFilters(filters);
+                DescribeTagsResult response = ec2Client().describeTags(request);
+
+                Map<String,String> result = new HashMap<>();
+                for (TagDescription desc : response.getTags())
+                {
+                    result.put(desc.getKey(), desc.getValue());
+                }
+                return result;
+            }
+            catch (AmazonEC2Exception ex)
+            {
+                // this code determined via experimentation
+                if ("RequestLimitExceeded".equals(ex.getErrorCode()))
+                    return null;
+                return new HashMap<>();
+            }
+            catch (Exception ignored)
+            {
+                return new HashMap<>();
+            }
+        });
     }
 
 
@@ -112,11 +146,21 @@ implements InfoFacade
 //  Internals
 //----------------------------------------------------------------------------
 
+    protected RetryManager retryManager = new RetryManager(50, 1000, true);
+
+    private AmazonEC2 ec2Client;
     private AWSSecurityTokenService stsClient;
     private AWSSimpleSystemsManagement ssmClient;
 
-    protected RetryManager retryManager = new RetryManager(50, 1000, true);
 
+    protected AmazonEC2 ec2Client()
+    {
+        if (ec2Client == null)
+        {
+            ec2Client = AmazonEC2ClientBuilder.defaultClient();
+        }
+        return ec2Client;
+    }
 
     protected AWSSecurityTokenService stsClient()
     {

--- a/library/aws-facade-v1/src/test/java/com/kdgregory/logging/aws/testhelpers/EC2ClientMock.java
+++ b/library/aws-facade-v1/src/test/java/com/kdgregory/logging/aws/testhelpers/EC2ClientMock.java
@@ -1,0 +1,136 @@
+// Copyright (c) Keith D Gregory
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.kdgregory.logging.aws.testhelpers;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import net.sf.kdgcommons.collections.CollectionUtil;
+
+import com.amazonaws.services.ec2.AmazonEC2;
+import com.amazonaws.services.ec2.model.*;
+
+
+/**
+ *  Supports mock-object testing of facade code that uses EC2.
+ *  <p>
+ *  This is a proxy-based mock: you create an instance of the mock, and from it
+ *  create an instance of a proxy that implements the client interface. Each of
+ *  the supported client methods is implemented in the mock, and called from the
+ *  invocation handler. To test specific behaviors, subclasses should override
+ *  the method implementation.
+ *  <p>
+ *  Each method has an associated invocation counter, along with variables that
+ *  hold the last set of arguments passed to this method. These variables are
+ *  public, to minimize boilerplate code; if testcases modify the variables, they
+ *  only hurt themselves.
+ *  <p>
+ *  The mock is assumed to be invoked from a single thread, so no effort has been
+ *  taken to make it threadsafe.
+ */
+public class EC2ClientMock
+implements InvocationHandler
+{
+    // this map holds the tags that will be returned from a DescribeTags call
+    // it must be populated by the testcase
+    public Map<String,String> describeTagsValues = new HashMap<>();
+
+    // invocation counts for known methods
+    public int describeTagsInvocationCount;
+
+    // information passed to DescribeTags
+    public Set<String> describeTagsFilterTypes;
+    public String describeTagsResourceType;
+    public String describeTagsResourceId;
+
+//----------------------------------------------------------------------------
+//  Public methods
+//----------------------------------------------------------------------------
+
+    public AmazonEC2 createClient()
+    {
+        return (AmazonEC2)Proxy.newProxyInstance(
+                                    getClass().getClassLoader(),
+                                    new Class<?>[] { AmazonEC2.class },
+                                    EC2ClientMock.this);
+    }
+
+//----------------------------------------------------------------------------
+//  Invocation Handler
+//----------------------------------------------------------------------------
+
+    /**
+     *  The invocation handler; test code should not care about this.
+     */
+    @Override
+    public Object invoke(Object proxy, Method method, Object[] args) throws Throwable
+    {
+        String methodName = method.getName();
+        if (methodName.equals("describeTags"))
+        {
+            describeTagsInvocationCount++;
+            DescribeTagsRequest request = (DescribeTagsRequest)args[0];
+            describeTagsFilterTypes = new HashSet<>();
+            describeTagsResourceType = null;
+            describeTagsResourceId = null;
+            for (Filter filter : request.getFilters())
+            {
+                describeTagsFilterTypes.add(filter.getName());
+                switch (filter.getName())
+                {
+                    case "resource-id":
+                        describeTagsResourceId = CollectionUtil.first(filter.getValues());
+                        break;
+                    case "resource-type":
+                        describeTagsResourceType = CollectionUtil.first(filter.getValues());
+                        break;
+                    default:
+                        // do nothing
+                }
+            }
+            return describeTags(request);
+        }
+
+        // if nothing matches, fall through to here
+        System.err.println("invocation handler called unexpectedly: " + methodName);
+        throw new IllegalArgumentException("unexpected client call: " + methodName);
+    }
+
+//----------------------------------------------------------------------------
+//  Default mock implementations
+//----------------------------------------------------------------------------
+
+    public DescribeTagsResult describeTags(DescribeTagsRequest request)
+    {
+        List<TagDescription> tags = new ArrayList<>();
+        for (Map.Entry<String,String> entry : describeTagsValues.entrySet())
+        {
+            TagDescription desc = new TagDescription()
+                                  .withResourceType(describeTagsResourceType)
+                                  .withResourceId(describeTagsResourceId)
+                                  .withKey(entry.getKey())
+                                  .withValue(entry.getValue());
+            tags.add(desc);
+        }
+        return new DescribeTagsResult().withTags(tags);
+    }
+}

--- a/library/aws-facade-v2/pom.xml
+++ b/library/aws-facade-v2/pom.xml
@@ -27,6 +27,13 @@
         
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
+            <artifactId>ec2</artifactId>
+            <version>${aws-sdk-v2.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
             <artifactId>iam</artifactId>
             <version>${aws-sdk-v2.version}</version>
             <scope>provided</scope>

--- a/library/aws-facade-v2/src/main/java/com/kdgregory/logging/aws/facade/v2/InfoFacadeImpl.java
+++ b/library/aws-facade-v2/src/main/java/com/kdgregory/logging/aws/facade/v2/InfoFacadeImpl.java
@@ -22,6 +22,8 @@ import software.amazon.awssdk.services.ssm.model.*;
 import software.amazon.awssdk.services.sts.StsClient;
 import software.amazon.awssdk.services.sts.model.*;
 
+import java.util.Map;
+
 import com.kdgregory.logging.aws.facade.InfoFacade;
 import com.kdgregory.logging.common.util.RetryManager;
 
@@ -66,6 +68,13 @@ implements InfoFacade
     public String retrieveEC2Region()
     {
         return EC2MetadataUtils.getEC2InstanceRegion();
+    }
+
+
+    @Override
+    public Map<String,String> retrieveEC2Tags(String instanceId)
+    {
+        throw new UnsupportedOperationException("FIXME - implement");
     }
 
 

--- a/library/aws-facade-v2/src/test/java/com/kdgregory/logging/aws/testhelpers/EC2ClientMock.java
+++ b/library/aws-facade-v2/src/test/java/com/kdgregory/logging/aws/testhelpers/EC2ClientMock.java
@@ -1,0 +1,137 @@
+// Copyright (c) Keith D Gregory
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.kdgregory.logging.aws.testhelpers;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import net.sf.kdgcommons.collections.CollectionUtil;
+
+import software.amazon.awssdk.services.ec2.Ec2Client;
+import software.amazon.awssdk.services.ec2.model.*;
+
+
+/**
+ *  Supports mock-object testing of facade code that uses EC2.
+ *  <p>
+ *  This is a proxy-based mock: you create an instance of the mock, and from it
+ *  create an instance of a proxy that implements the client interface. Each of
+ *  the supported client methods is implemented in the mock, and called from the
+ *  invocation handler. To test specific behaviors, subclasses should override
+ *  the method implementation.
+ *  <p>
+ *  Each method has an associated invocation counter, along with variables that
+ *  hold the last set of arguments passed to this method. These variables are
+ *  public, to minimize boilerplate code; if testcases modify the variables, they
+ *  only hurt themselves.
+ *  <p>
+ *  The mock is assumed to be invoked from a single thread, so no effort has been
+ *  taken to make it threadsafe.
+ */
+public class EC2ClientMock
+implements InvocationHandler
+{
+    // this map holds the tags that will be returned from a DescribeTags call
+    // it must be populated by the testcase
+    public Map<String,String> describeTagsValues = new HashMap<>();
+
+    // invocation counts for known methods
+    public int describeTagsInvocationCount;
+
+    // information passed to DescribeTags
+    public Set<String> describeTagsFilterTypes;
+    public String describeTagsResourceType;
+    public String describeTagsResourceId;
+
+//----------------------------------------------------------------------------
+//  Public methods
+//----------------------------------------------------------------------------
+
+    public Ec2Client createClient()
+    {
+        return (Ec2Client)Proxy.newProxyInstance(
+                                    getClass().getClassLoader(),
+                                    new Class<?>[] { Ec2Client.class },
+                                    EC2ClientMock.this);
+    }
+
+//----------------------------------------------------------------------------
+//  Invocation Handler
+//----------------------------------------------------------------------------
+
+    /**
+     *  The invocation handler; test code should not care about this.
+     */
+    @Override
+    public Object invoke(Object proxy, Method method, Object[] args) throws Throwable
+    {
+        String methodName = method.getName();
+        if (methodName.equals("describeTags"))
+        {
+            describeTagsInvocationCount++;
+            DescribeTagsRequest request = (DescribeTagsRequest)args[0];
+            describeTagsFilterTypes = new HashSet<>();
+            describeTagsResourceType = null;
+            describeTagsResourceId = null;
+            for (Filter filter : request.filters())
+            {
+                describeTagsFilterTypes.add(filter.name());
+                switch (filter.name())
+                {
+                    case "resource-id":
+                        describeTagsResourceId = CollectionUtil.first(filter.values());
+                        break;
+                    case "resource-type":
+                        describeTagsResourceType = CollectionUtil.first(filter.values());
+                        break;
+                    default:
+                        // do nothing
+                }
+            }
+            return describeTags(request);
+        }
+
+        // if nothing matches, fall through to here
+        System.err.println("invocation handler called unexpectedly: " + methodName);
+        throw new IllegalArgumentException("unexpected client call: " + methodName);
+    }
+
+//----------------------------------------------------------------------------
+//  Default mock implementations
+//----------------------------------------------------------------------------
+
+    public DescribeTagsResponse describeTags(DescribeTagsRequest request)
+    {
+        List<TagDescription> tags = new ArrayList<>();
+        for (Map.Entry<String,String> entry : describeTagsValues.entrySet())
+        {
+            TagDescription desc = TagDescription.builder()
+                                  .resourceType(describeTagsResourceType)
+                                  .resourceId(describeTagsResourceId)
+                                  .key(entry.getKey())
+                                  .value(entry.getValue())
+                                  .build();
+            tags.add(desc);
+        }
+        return DescribeTagsResponse.builder().tags(tags).build();
+    }
+}

--- a/library/shared/src/main/java/com/kdgregory/logging/aws/facade/InfoFacade.java
+++ b/library/shared/src/main/java/com/kdgregory/logging/aws/facade/InfoFacade.java
@@ -14,6 +14,7 @@
 
 package com.kdgregory.logging.aws.facade;
 
+import java.util.Map;
 
 /**
  *  A facade for various operations that retrieve information about the
@@ -63,6 +64,13 @@ public interface InfoFacade
      *  See {@link #retrieveRegion}, which uses the default region provider.
      */
     String retrieveEC2Region();
+    
+    
+    /**
+     *  Returns all tags for the specified EC2 instance. Returns an empty map if unable to
+     *  retrieve these tags for any reason (eg, invalid instance ID, permission denied).
+     */
+    Map<String,String> retrieveEC2Tags(String instanceId);
 
 
     /**

--- a/library/shared/src/test/java/com/kdgregory/logging/aws/TestSubstitutions.java
+++ b/library/shared/src/test/java/com/kdgregory/logging/aws/TestSubstitutions.java
@@ -18,6 +18,7 @@ import java.lang.management.ManagementFactory;
 import java.lang.management.RuntimeMXBean;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.Map;
 import java.util.TimeZone;
 
 import org.junit.BeforeClass;
@@ -222,6 +223,28 @@ public class TestSubstitutions
 
         Substitutions subs = new Substitutions(TEST_DATE, 123, mockInfoFacade);
         assertEquals("us-east-1", subs.perform("{ec2:region}"));
+    }
+
+
+    @Test
+    public void testEC2InstanceTag() throws Exception
+    {
+        mockInfoFacade = new MockInfoFacade()
+        {
+            @Override
+            public Map<String,String> retrieveEC2Tags(String instanceId)
+            {
+                assertEquals("passed correct instance ID", ec2InstanceId, instanceId);
+                return ec2InstanceTags;
+            }
+        };
+
+        mockInfoFacade.ec2InstanceId = "i-1234567890";
+        mockInfoFacade.ec2InstanceTags.put("FOO", "bar");
+        mockInfoFacade.ec2InstanceTags.put("ARGLE", "bargle");
+
+        Substitutions subs = new Substitutions(TEST_DATE, 123, mockInfoFacade);
+        assertEquals("bar unknown bargle", subs.perform("{ec2:tag:FOO} {ec2:tag:foo} {ec2:tag:ARGLE}"));
     }
 
 

--- a/library/shared/src/test/java/com/kdgregory/logging/testhelpers/MockInfoFacade.java
+++ b/library/shared/src/test/java/com/kdgregory/logging/testhelpers/MockInfoFacade.java
@@ -23,7 +23,8 @@ import com.kdgregory.logging.aws.facade.InfoFacade;
 /**
  *  Simple mock-object, used for testing Substitutions. Rather than go through any
  *  sort of proxy operation, or even much configuration, all of the returned values
- *  are configured as public member variables.
+ *  are configured as public member variables, which you can update as part of your
+ *  test setup.
  */
 public class MockInfoFacade
 implements InfoFacade
@@ -32,6 +33,7 @@ implements InfoFacade
     public String defaultRegion;
     public String ec2InstanceId;
     public String ec2Region;
+    public Map<String,String> ec2InstanceTags = new HashMap<>();
     public Map<String,String> parameterValues = new HashMap<>();
 
 
@@ -59,10 +61,16 @@ implements InfoFacade
         return ec2Region;
     }
 
+
+    @Override
+    public Map<String,String> retrieveEC2Tags(String instanceId)
+    {
+        return ec2InstanceTags;
+    }
+
     @Override
     public String retrieveParameter(String parameterName)
     {
         return parameterValues.get(parameterName);
     }
-
 }


### PR DESCRIPTION
In retrospect, this isn't that useful: it doesn't help people running on Lambda, or on ECS Fargate (and maybe not even ECS EC2). But it was a good validation of the `InfoFacade`.